### PR TITLE
Fault injection

### DIFF
--- a/ref/Makefile
+++ b/ref/Makefile
@@ -5,7 +5,7 @@ SOURCES = sign.c polyvec.c packing.c poly.c reduce.c ntt.c rounding.c fips202.c
 HEADERS = api.h params.h sign.h polyvec.h packing.h poly.h reduce.h ntt.h \
   rounding.h fips202.h
 
-all: PQCgenKAT_sign test/test_vectors test/test_dilithium
+all: PQCgenKAT_sign test/test_vectors test/test_dilithium test/test_fuzz
 
 PQCgenKAT_sign: $(SOURCES) rng.c PQCgenKAT_sign.c $(HEADERS) rng.h
 	$(CC) $(NISTFLAGS) $(SOURCES) rng.c PQCgenKAT_sign.c -o $@ -lcrypto -ldl
@@ -18,6 +18,11 @@ test/test_dilithium: $(SOURCES) randombytes.c test/test_dilithium.c \
   test/cpucycles.h
 	$(CC) $(CFLAGS) $(SOURCES) randombytes.c test/test_dilithium.c \
 	  test/speed.c test/cpucycles.c -o $@
+
+test/test_fuzz: $(SOURCES) randombytes.c test/test_fuzz.c \
+  $(HEADERS) randombytes.h
+	$(CC) $(CFLAGS) $(SOURCES) randombytes.c test/test_fuzz.c -o $@
+
 
 test/test_mul: reduce.c ntt.c randombytes.c test/test_mul.c \
   test/speed.c test/cpucycles.c params.h reduce.h ntt.h randombytes.h \
@@ -33,3 +38,4 @@ clean:
 	rm -f test/test_vectors
 	rm -f test/test_dilithium
 	rm -f test/test_mul
+	rm -f test/test_fuzz

--- a/ref/packing.c
+++ b/ref/packing.c
@@ -205,7 +205,7 @@ void pack_sig(unsigned char sig[SIG_SIZE_PACKED],
 *              - const poly *c: pointer to output challenge polynomial
 *              - unsigned char sig[]: byte array containing bit-packed signature
 **************************************************/
-void unpack_sig(polyvecl *z,
+int unpack_sig(polyvecl *z,
                 polyveck *h,
                 poly *c,
                 const unsigned char sig[SIG_SIZE_PACKED])
@@ -223,6 +223,8 @@ void unpack_sig(polyvecl *z,
     for(j = 0; j < N; ++j)
       h->vec[i].coeffs[j] = 0;
 
+    if ((sig + sig[OMEGA+i]) > (sig - L*POLZ_SIZE_PACKED + SIG_SIZE_PACKED))
+      return 0;
     for(j = k; j < sig[OMEGA + i]; ++j)
       h->vec[i].coeffs[sig[j]] = 1;
 
@@ -247,4 +249,5 @@ void unpack_sig(polyvecl *z,
       }
     }
   }
+  return 1;
 }

--- a/ref/packing.h
+++ b/ref/packing.h
@@ -24,7 +24,7 @@ void unpack_sk(unsigned char rho[SEEDBYTES],
                polyveck *s2,
                polyveck *t0,
                const unsigned char sk[SK_SIZE_PACKED]);
-void unpack_sig(polyvecl *z, polyveck *h, poly *c,
+int unpack_sig(polyvecl *z, polyveck *h, poly *c,
                 const unsigned char sig[SIG_SIZE_PACKED]);
 
 #endif

--- a/ref/sign.c
+++ b/ref/sign.c
@@ -314,6 +314,7 @@ int crypto_sign_open(unsigned char *m,
   poly     c, chat, cp;
   polyvecl mat[K], z;
   polyveck t1, w1, h, tmp1, tmp2;
+  int      ret = -2;
 
   if(smlen < CRYPTO_BYTES)
     goto badsig;
@@ -321,7 +322,10 @@ int crypto_sign_open(unsigned char *m,
   *mlen = smlen - CRYPTO_BYTES;
 
   unpack_pk(rho, &t1, pk);
-  unpack_sig(&z, &h, &c, sm);
+  if (!unpack_sig(&z, &h, &c, sm))
+    goto badsig;
+  ret = -1;
+
   if(polyvecl_chknorm(&z, GAMMA1 - BETA))
     goto badsig;
 
@@ -377,5 +381,5 @@ int crypto_sign_open(unsigned char *m,
   for(i = 0; i < smlen; ++i)
     m[i] = 0;
   
-  return -1;
+  return ret;
 }

--- a/ref/test/test_fuzz.c
+++ b/ref/test/test_fuzz.c
@@ -28,7 +28,7 @@ int main(int argc, const char **argv)
   for(i = 0; i < NTESTS; ++i) {
     crypto_sign(sm, &smlen, m, MLEN, sk);
     for (j = 0; j < fbits; j++)
-      sm[MLEN+rand()%CRYPTO_BYTES] ^= 1<<(rand()&7);
+      sm[rand()%CRYPTO_BYTES] ^= 1<<(rand()&7);
     ret = crypto_sign_open(m2, &mlen, sm, smlen, pk);
     under_radar += !ret;
   }

--- a/ref/test/test_fuzz.c
+++ b/ref/test/test_fuzz.c
@@ -1,0 +1,40 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include "../api.h"
+#include "../randombytes.h"
+
+#define MLEN 59
+#define NTESTS 100000
+
+int main(int argc, const char **argv)
+{
+  int i, j;
+  int ret, under_radar = 0;
+  unsigned long long mlen, smlen;
+  unsigned char m[MLEN];
+  unsigned char sm[MLEN + CRYPTO_BYTES];
+  unsigned char m2[MLEN + CRYPTO_BYTES];
+  unsigned char pk[CRYPTO_PUBLICKEYBYTES];
+  unsigned char sk[CRYPTO_SECRETKEYBYTES];
+
+  int fbits = 1;
+  if (argc > 1)
+    fbits = atoi(argv[1]);
+
+  under_radar = 0;
+    randombytes(m, MLEN);
+    crypto_sign_keypair(pk, sk);
+
+  for(i = 0; i < NTESTS; ++i) {
+    crypto_sign(sm, &smlen, m, MLEN, sk);
+    for (j = 0; j < fbits; j++)
+      sm[MLEN+rand()%CRYPTO_BYTES] ^= 1<<(rand()&7);
+    ret = crypto_sign_open(m2, &mlen, sm, smlen, pk);
+    under_radar += !ret;
+  }
+
+  printf("%d out of %d accepted (aka 1-in-%d) for %d-bit faults injected\n",
+		  under_radar, NTESTS, under_radar?(NTESTS/under_radar):-1, fbits);
+ 
+  return 0;
+}


### PR DESCRIPTION
This adds a fault injection test, flipping random bits in signatures. During testing, I've discovered signatures can reference invalid memory.

Surprisingly enough, these references made the appearing forgeries more frequent, roughly by a factor of 2. I have no idea what's going on, but simply checking for out of bounds access doesn't hurt in `sig_unpack()`.

For curious reader: this scheme and others similiar to it is by definition malleable, as it will accept random bit mutations with relative ease. 