### PR TITLE
macOS compatibility

### DIFF
--- a/avx2/Makefile
+++ b/avx2/Makefile
@@ -1,7 +1,7 @@
 CC ?= /usr/bin/cc
+NISTFLAGS += -march=native -mtune=native -O3 -fomit-frame-pointer $(CFLAGS)
 CFLAGS += -Wall -Wextra -march=native -mtune=native -O3 -fomit-frame-pointer
 #CFLAGS += -DMODE=3
-NISTFLAGS += -march=native -mtune=native -O3 -fomit-frame-pointer
 #NISTFLAGS += -DMODE=3
 SOURCES = sign.c polyvec.c poly.c packing.c ntt.s invntt.s pointwise.S \
   nttconsts.c rejsample.c reduce.s rounding.c

--- a/avx2/invntt.s
+++ b/avx2/invntt.s
@@ -1,6 +1,6 @@
 .include "shuffle.h"
 
-.macro butterfly l0,l1,l2,l3,h0,h1,h2,h3 z0=15,z1=3
+.macro butterfly l0,l1,l2,l3,h0,h1,h2,h3,z0=15,z1=3
 vpaddd		%ymm2,%ymm\l0,%ymm12
 vpaddd		%ymm2,%ymm\l1,%ymm13
 vpaddd		%ymm2,%ymm\l2,%ymm14
@@ -121,7 +121,7 @@ level2:
 #zetas
 vpmovzxdq	96(%rdx),%ymm3
 
-butterfly	4,5,6,7,8,9,10,11 3,3
+butterfly	4,5,6,7,8,9,10,11,3,3
 
 #shuffle
 shuffle4	4,5,3,5
@@ -135,7 +135,7 @@ vpbroadcastd	112(%rdx),%ymm14
 vpbroadcastd	116(%rdx),%ymm15
 vpblendd	$0xF0,%ymm15,%ymm14,%ymm10
 
-butterfly	3,4,6,8,5,7,9,11 10,10
+butterfly	3,4,6,8,5,7,9,11,10,10
 
 #shuffle
 shuffle8	3,4,10,4
@@ -147,7 +147,7 @@ level4:
 #zetas
 vpbroadcastd	120(%rdx),%ymm9
 
-butterfly	10,3,6,5,4,8,7,11 9,9
+butterfly	10,3,6,5,4,8,7,11,9,9
 
 #store
 vmovdqa		%ymm10,(%rdi)
@@ -233,7 +233,7 @@ level7:
 #zetas
 vpbroadcastd	24(%rdx),%ymm3
 
-butterfly	4,5,6,7,8,9,10,11 3,3
+butterfly	4,5,6,7,8,9,10,11,3,3
 
 #consts
 vmovdqa		_8xdiv(%rip),%ymm3

--- a/avx2/ntt.h
+++ b/avx2/ntt.h
@@ -9,19 +9,21 @@ extern const uint32_t zetas_inv[N];
 
 void ntt_levels0t2_avx(uint64_t tmp[N],
                        const uint32_t a[N],
-                       const uint32_t zetas[7]);
+                       const uint32_t zetas[7]) asm("ntt_levels0t2_avx");
 void ntt_levels3t8_avx(uint32_t a[N],
                        const uint64_t tmp[N],
-                       const uint32_t zetas[31]);
+                       const uint32_t zetas[31]) asm("ntt_levels3t8_avx");
 
 void invntt_levels0t4_avx(uint64_t tmp[N],
                           const uint32_t a[N],
-                          const uint32_t zetas_inv[31]);
+                          const uint32_t zetas_inv[31]) asm("invntt_levels0t4_avx");
 void invntt_levels5t7_avx(uint32_t a[N],
                           const uint64_t tmp[N],
-                          const uint32_t zetas_inv[7]);
+                          const uint32_t zetas_inv[7]) asm("invntt_levels5t7_avx");
 
-void pointwise_avx(uint32_t c[N], const uint32_t a[N], const uint32_t b[N]);
-void pointwise_acc_avx(uint32_t c[N], const uint32_t *a, const uint32_t *b);
+void pointwise_avx(uint32_t c[N], const uint32_t a[N], const uint32_t b[N])
+        asm("pointwise_avx");
+void pointwise_acc_avx(uint32_t c[N], const uint32_t *a, const uint32_t *b)
+        asm("pointwise_acc_avx");
 
 #endif

--- a/avx2/ntt.s
+++ b/avx2/ntt.s
@@ -1,6 +1,6 @@
 .include "shuffle.h"
 
-.macro butterfly rl0,rl1,rl2,rl3,rh0,rh1,rh2,rh3 z0=3,z1=3,z2=3,z3=3
+.macro butterfly rl0,rl1,rl2,rl3,rh0,rh1,rh2,rh3,z0=3,z1=3,z2=3,z3=3
 #mul
 vpmuludq	%ymm\z0,%ymm\rh0,%ymm\rh0
 vpmuludq	%ymm\z1,%ymm\rh1,%ymm\rh1
@@ -68,7 +68,7 @@ level1:
 vpbroadcastd	4(%rdx),%ymm12
 vpbroadcastd	8(%rdx),%ymm13
 
-butterfly	4,5,8,9,6,7,10,11 12,12,13,13
+butterfly	4,5,8,9,6,7,10,11,12,12,13,13
 
 level2:
 #zetas
@@ -77,7 +77,7 @@ vpbroadcastd	16(%rdx),%ymm13
 vpbroadcastd	20(%rdx),%ymm14
 vpbroadcastd	24(%rdx),%ymm15
 
-butterfly	4,6,8,10,5,7,9,11 12,13,14,15
+butterfly	4,6,8,10,5,7,9,11,12,13,14,15
 
 #store
 vmovdqa		%ymm4,(%rdi)
@@ -125,7 +125,7 @@ shuffle8	5,9,4,9
 shuffle8	6,10,5,10
 shuffle8	7,11,6,11
 
-butterfly	3,8,4,9,5,10,6,11 12,12,12,12
+butterfly	3,8,4,9,5,10,6,11,12,12,12,12
 
 level5:
 #zetas
@@ -136,14 +136,14 @@ shuffle4	8,10,3,10
 shuffle4	4,6,8,6
 shuffle4	9,11,4,11
 
-butterfly	7,5,3,10,8,6,4,11 12,12,12,12
+butterfly	7,5,3,10,8,6,4,11,12,12,12,12
 
 level6:
 #zetas
 vpmovzxdq	28(%rdx),%ymm12
 vpmovzxdq	44(%rdx),%ymm13
 
-butterfly	7,5,8,6,3,10,4,11 12,12,13,13
+butterfly	7,5,8,6,3,10,4,11,12,12,13,13
 
 level7:
 #zetas
@@ -152,7 +152,7 @@ vpmovzxdq	76(%rdx),%ymm13
 vpmovzxdq	92(%rdx),%ymm14
 vpmovzxdq	108(%rdx),%ymm15
 
-butterfly	7,3,8,4,5,10,6,11 12,13,14,15
+butterfly	7,3,8,4,5,10,6,11,12,13,14,15
 
 #store
 vpsllq		$32,%ymm5,%ymm5

--- a/avx2/nttconsts.c
+++ b/avx2/nttconsts.c
@@ -5,20 +5,20 @@
 #define MONT 4193792ULL
 #define DIV (((MONT*MONT % Q) * (Q-1) % Q) * ((Q-1) >> 8) % Q)
 
-const uint32_t _8xqinv[8] __attribute__((aligned(32)))
+const uint32_t _8xqinv[8] asm("_8xqinv") __attribute__((aligned(32)))
   = {QINV, QINV, QINV, QINV, QINV, QINV, QINV, QINV};
-const uint32_t _8xq[8] __attribute__((aligned(32)))
+const uint32_t _8xq[8] asm("_8xq") __attribute__((aligned(32)))
   = {Q, Q, Q, Q, Q, Q, Q, Q};
-const uint32_t _8x2q[8] __attribute__((aligned(32)))
+const uint32_t _8x2q[8] asm("_8x2q") __attribute__((aligned(32)))
   = {2*Q, 2*Q, 2*Q, 2*Q, 2*Q, 2*Q, 2*Q, 2*Q};
-const uint32_t _8x256q[8] __attribute__((aligned(32)))
+const uint32_t _8x256q[8] asm("_8x256q")  __attribute__((aligned(32)))
   = {256*Q, 256*Q, 256*Q, 256*Q, 256*Q, 256*Q, 256*Q, 256*Q};
-const uint32_t _mask[8] __attribute__((aligned(32)))
+const uint32_t _mask[8] asm("_mask") __attribute__((aligned(32)))
   = {0, 2, 4, 6, 0, 0, 0, 0};
-const uint32_t _8x23ones[8]  __attribute__((aligned(32)))
+const uint32_t _8x23ones[8] asm("_8x23ones") __attribute__((aligned(32)))
   = {0x7FFFFF, 0x7FFFFF, 0x7FFFFF, 0x7FFFFF, 0x7FFFFF, 0x7FFFFF, 0x7FFFFF,
      0x7FFFFF};
-const uint32_t _8xdiv[8] __attribute__((aligned(32))) = {DIV, DIV, DIV, DIV, DIV, DIV, DIV, DIV};
+const uint32_t _8xdiv[8] asm("_8xdiv") __attribute__((aligned(32))) = {DIV, DIV, DIV, DIV, DIV, DIV, DIV, DIV};
 
 #undef QINV
 #undef MONT

--- a/avx2/poly.c
+++ b/avx2/poly.c
@@ -14,7 +14,7 @@ extern const unsigned long long timing_overhead;
 extern unsigned long long *tred, *tadd, *tmul, *tround, *tsample, *tpack;
 #endif
 
-extern const uint32_t _8x2q[8];
+extern const uint32_t _8x2q[8] asm("_8x2q");
 
 /*************************************************
 * Name:        poly_reduce

--- a/avx2/reduce.h
+++ b/avx2/reduce.h
@@ -3,7 +3,7 @@
 
 #include <stdint.h>
 
-void reduce_avx(uint32_t a[N]);
-void csubq_avx(uint32_t a[N]);
+void reduce_avx(uint32_t a[N]) asm("reduce_avx");
+void csubq_avx(uint32_t a[N]) asm("csubq_avx");
 
 #endif

--- a/ref/Makefile
+++ b/ref/Makefile
@@ -1,7 +1,7 @@
 CC ?= /usr/bin/cc
+NISTFLAGS += $(CFLAGS) -march=native -mtune=native -O3 -fomit-frame-pointer
 CFLAGS += -Wall -Wextra -march=native -mtune=native -O3 -fomit-frame-pointer
 #CFLAGS += -DMODE=3
-NISTFLAGS += -march=native -mtune=native -O3 -fomit-frame-pointer
 #NISTFLAGS += -DMODE=3
 SOURCES = sign.c polyvec.c poly.c packing.c ntt.c reduce.c rounding.c
 HEADERS = config.h api.h params.h sign.h polyvec.h poly.h packing.h ntt.h \

--- a/ref/test/runtests.sh
+++ b/ref/test/runtests.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 
 make clean;
 


### PR DESCRIPTION
 - Force symbol names without underscores using asm attribute (the
   alternative -fno-leading-underscore will break OpenSSL compilation.)
 - Include environment CFLAGS into NISTFLAGS to allow -I directives to
   be passed easily.
 - Use comma instead of space to separate the optional arguments in the
   butterfly macro.  For some reason clang 10 doesn't like them with a
   space.