### PR TITLE
added LDFLAGS -- to work around OSX -lcrypto weirdness

### DIFF
--- a/avx2/Makefile
+++ b/avx2/Makefile
@@ -2,6 +2,7 @@ CC = /usr/bin/cc
 CFLAGS += -Wall -Wextra -Wpedantic -Wmissing-prototypes -Wredundant-decls \
   -Wshadow -Wpointer-arith -march=native -mtune=native -O3 \
   -fomit-frame-pointer -flto
+LDFLAGS=
 NISTFLAGS += -Wno-unused-result -march=native -mtune=native -O3
 SOURCES = sign.c packing.c polyvec.c poly.c ntt.S invntt.S pointwise.S \
   consts.c rejsample.c reduce.S rounding.c
@@ -12,6 +13,12 @@ KECCAK_SOURCES = $(SOURCES) fips202.c fips202x4.c symmetric-shake.c \
 KECCAK_HEADERS = $(HEADERS) fips202.h fips202x4.h
 AES_SOURCES = $(SOURCES) fips202.c aes256ctr.c
 AES_HEADERS = $(HEADERS) fips202.h aes256ctr.h
+
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+    # don't link against system openssl (libressl)
+    LDFLAGS += -L/usr/local/Cellar/openssl@1.1/1.1.1d/lib
+endif
 
 .PHONY: all shared clean
 
@@ -129,32 +136,32 @@ test/test_dilithium4aes: test/test_dilithium.c randombytes.c $(AES_SOURCES) \
 test/test_vectors2: test/test_vectors.c rng.c rng.h $(KECCAK_SOURCES) \
   $(KECCAK_HEADERS)
 	$(CC) $(NISTFLAGS) -DDILITHIUM_MODE=2 \
-	  -o $@ $< rng.c $(KECCAK_SOURCES) -lcrypto
+	  -o $@ $< rng.c $(KECCAK_SOURCES) $(LDFLAGS) -lcrypto
 
 test/test_vectors3: test/test_vectors.c rng.c rng.h $(KECCAK_SOURCES) \
   $(KECCAK_HEADERS)
 	$(CC) $(NISTFLAGS) -DDILITHIUM_MODE=3 \
-	  -o $@ $< rng.c $(KECCAK_SOURCES) -lcrypto
+	  -o $@ $< rng.c $(KECCAK_SOURCES) $(LDFLAGS) -lcrypto
 
 test/test_vectors4: test/test_vectors.c rng.c rng.h $(KECCAK_SOURCES) \
   $(KECCAK_HEADERS)
 	$(CC) $(NISTFLAGS) -DDILITHIUM_MODE=4 \
-	  -o $@ $< rng.c $(KECCAK_SOURCES) -lcrypto
+	  -o $@ $< rng.c $(KECCAK_SOURCES) $(LDFLAGS) -lcrypto
 
 test/test_vectors2aes: test/test_vectors.c rng.c rng.h $(AES_SOURCES) \
   $(AES_HEADERS)
 	$(CC) $(NISTFLAGS) -DDILITHIUM_MODE=2 -DDILITHIUM_USE_AES \
-	  -o $@ $< rng.c $(AES_SOURCES) -lcrypto
+	  -o $@ $< rng.c $(AES_SOURCES) $(LDFLAGS) -lcrypto
 
 test/test_vectors3aes: test/test_vectors.c rng.c rng.h $(AES_SOURCES) \
   $(AES_HEADERS)
 	$(CC) $(NISTFLAGS) -DDILITHIUM_MODE=3 -DDILITHIUM_USE_AES \
-	  -o $@ $< rng.c $(AES_SOURCES) -lcrypto
+	  -o $@ $< rng.c $(AES_SOURCES) $(LDFLAGS) -lcrypto
 
 test/test_vectors4aes: test/test_vectors.c rng.c rng.h $(AES_SOURCES) \
   $(AES_HEADERS)
 	$(CC) $(NISTFLAGS) -DDILITHIUM_MODE=4 -DDILITHIUM_USE_AES \
-	  -o $@ $< rng.c $(AES_SOURCES) -lcrypto
+	  -o $@ $< rng.c $(AES_SOURCES) $(LDFLAGS) -lcrypto
 
 test/test_speed2: test/test_speed.c test/speed_print.c test/speed_print.h \
   test/cpucycles.c test/cpucycles.h randombytes.c $(KECCAK_SOURCES) \
@@ -205,29 +212,29 @@ test/test_mul: test/test_mul.c randombytes.c $(KECCAK_SOURCES) \
 PQCgenKAT_sign2: PQCgenKAT_sign.c rng.c rng.h $(KECCAK_SOURCES) \
   $(KECCAK_HEADERS)
 	$(CC) $(NISTFLAGS) -DDILITHIUM_MODE=2 \
-	  -o $@ $< rng.c $(KECCAK_SOURCES) -lcrypto
+	  -o $@ $< rng.c $(KECCAK_SOURCES) $(LDFLAGS) -lcrypto
 
 PQCgenKAT_sign3: PQCgenKAT_sign.c rng.c rng.h $(KECCAK_SOURCES) \
   $(KECCAK_HEADERS)
 	$(CC) $(NISTFLAGS) -DDILITHIUM_MODE=3 \
-	  -o $@ $< rng.c $(KECCAK_SOURCES) -lcrypto
+	  -o $@ $< rng.c $(KECCAK_SOURCES) $(LDFLAGS) -lcrypto
 
 PQCgenKAT_sign4: PQCgenKAT_sign.c rng.c rng.h $(KECCAK_SOURCES) \
   $(KECCAK_HEADERS)
 	$(CC) $(NISTFLAGS) -DDILITHIUM_MODE=4 \
-	  -o $@ $< rng.c $(KECCAK_SOURCES) -lcrypto
+	  -o $@ $< rng.c $(KECCAK_SOURCES) $(LDFLAGS) -lcrypto
 
 PQCgenKAT_sign2aes: PQCgenKAT_sign.c rng.c rng.h $(AES_SOURCES) $(AES_HEADERS)
 	$(CC) $(NISTFLAGS) -DDILITHIUM_MODE=2 -DDILITHIUM_USE_AES \
-	  -o $@ $< rng.c $(AES_SOURCES) -lcrypto
+	  -o $@ $< rng.c $(AES_SOURCES) $(LDFLAGS) -lcrypto
 
 PQCgenKAT_sign3aes: PQCgenKAT_sign.c rng.c rng.h $(AES_SOURCES) $(AES_HEADERS)
 	$(CC) $(NISTFLAGS) -DDILITHIUM_MODE=3 -DDILITHIUM_USE_AES \
-	  -o $@ $< rng.c $(AES_SOURCES) -lcrypto
+	  -o $@ $< rng.c $(AES_SOURCES) $(LDFLAGS) -lcrypto
 
 PQCgenKAT_sign4aes: PQCgenKAT_sign.c rng.c rng.h $(AES_SOURCES) $(AES_HEADERS)
 	$(CC) $(NISTFLAGS) -DDILITHIUM_MODE=4 -DDILITHIUM_USE_AES \
-	  -o $@ $< rng.c $(AES_SOURCES) -lcrypto
+	  -o $@ $< rng.c $(AES_SOURCES) $(LDFLAGS) -lcrypto
 
 clean:
 	rm -f *.o *.a *.so

--- a/ref/Makefile
+++ b/ref/Makefile
@@ -1,6 +1,8 @@
+
 CC ?= /usr/bin/cc
 CFLAGS += -Wall -Wextra -Wpedantic -Wmissing-prototypes -Wredundant-decls \
    -Wshadow -Wpointer-arith -march=native -mtune=native -O3
+LDFLAGS=
 NISTFLAGS += -Wno-unused-result -march=native -mtune=native -O3
 SOURCES = sign.c packing.c polyvec.c poly.c ntt.c reduce.c rounding.c
 HEADERS = config.h params.h api.h sign.h packing.h polyvec.h poly.h ntt.h \
@@ -9,6 +11,12 @@ KECCAK_SOURCES = $(SOURCES) fips202.c symmetric-shake.c
 KECCAK_HEADERS = $(HEADERS) fips202.h
 AES_SOURCES = $(SOURCES) fips202.c aes256ctr.c symmetric-aes.c
 AES_HEADERS = $(HEADERS) fips202.h aes256ctr.h
+
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+    # don't link against system openssl (libressl)
+    LDFLAGS += -L/usr/local/Cellar/openssl@1.1/1.1.1d/lib
+endif
 
 .PHONY: all shared clean
 
@@ -111,32 +119,32 @@ test/test_dilithium4aes: test/test_dilithium.c randombytes.c $(AES_SOURCES) \
 test/test_vectors2: test/test_vectors.c rng.c rng.h $(KECCAK_SOURCES) \
   $(KECCAK_HEADERS)
 	$(CC) $(NISTFLAGS) -DDILITHIUM_MODE=2 \
-	  -o $@ $< rng.c $(KECCAK_SOURCES) -lcrypto
+	  -o $@ $< rng.c $(KECCAK_SOURCES) $(LDFLAGS) -lcrypto
 
 test/test_vectors3: test/test_vectors.c rng.c rng.h $(KECCAK_SOURCES) \
   $(KECCAK_HEADERS)
 	$(CC) $(NISTFLAGS) -DDILITHIUM_MODE=3 \
-	  -o $@ $< rng.c $(KECCAK_SOURCES) -lcrypto
+	  -o $@ $< rng.c $(KECCAK_SOURCES) $(LDFLAGS) -lcrypto
 
 test/test_vectors4: test/test_vectors.c rng.c rng.h $(KECCAK_SOURCES) \
   $(KECCAK_HEADERS)
 	$(CC) $(NISTFLAGS) -DDILITHIUM_MODE=4 \
-	  -o $@ $< rng.c $(KECCAK_SOURCES) -lcrypto
+	  -o $@ $< rng.c $(KECCAK_SOURCES) $(LDFLAGS) -lcrypto
 
 test/test_vectors2aes: test/test_vectors.c rng.c rng.h $(AES_SOURCES) \
   $(AES_HEADERS)
 	$(CC) $(NISTFLAGS) -DDILITHIUM_MODE=2 -DDILITHIUM_USE_AES \
-	  -o $@ $< rng.c $(AES_SOURCES) -lcrypto
+	  -o $@ $< rng.c $(AES_SOURCES) $(LDFLAGS) -lcrypto
 
 test/test_vectors3aes: test/test_vectors.c rng.c rng.h $(AES_SOURCES) \
   $(AES_HEADERS)
 	$(CC) $(NISTFLAGS) -DDILITHIUM_MODE=3 -DDILITHIUM_USE_AES \
-	  -o $@ $< rng.c $(AES_SOURCES) -lcrypto
+	  -o $@ $< rng.c $(AES_SOURCES) $(LDFLAGS) -lcrypto
 
 test/test_vectors4aes: test/test_vectors.c rng.c rng.h $(AES_SOURCES) \
   $(AES_HEADERS)
 	$(CC) $(NISTFLAGS) -DDILITHIUM_MODE=4 -DDILITHIUM_USE_AES \
-	  -o $@ $< rng.c $(AES_SOURCES) -lcrypto
+	  -o $@ $< rng.c $(AES_SOURCES) $(LDFLAGS) -lcrypto
 
 test/test_speed2: test/test_speed.c test/speed_print.c test/speed_print.h \
   test/cpucycles.c test/cpucycles.h randombytes.c $(KECCAK_SOURCES) \
@@ -183,32 +191,32 @@ test/test_mul: test/test_mul.c randombytes.c $(KECCAK_SOURCES) $(KECCAK_HEADERS)
 PQCgenKAT_sign2: PQCgenKAT_sign.c rng.c rng.h $(KECCAK_SOURCES) \
   $(KECCAK_HEADERS)
 	$(CC) $(NISTFLAGS) -DDILITHIUM_MODE=2 \
-	  -o $@ $< rng.c $(KECCAK_SOURCES) -lcrypto
+	  -o $@ $< rng.c $(KECCAK_SOURCES) $(LDFLAGS) -lcrypto
 
 PQCgenKAT_sign3: PQCgenKAT_sign.c rng.c rng.h $(KECCAK_SOURCES) \
   $(KECCAK_HEADERS)
 	$(CC) $(NISTFLAGS) -DDILITHIUM_MODE=3 \
-	  -o $@ $< rng.c $(KECCAK_SOURCES) -lcrypto
+	  -o $@ $< rng.c $(KECCAK_SOURCES) $(LDFLAGS) -lcrypto
 
 PQCgenKAT_sign4: PQCgenKAT_sign.c rng.c rng.h $(KECCAK_SOURCES) \
   $(KECCAK_HEADERS)
 	$(CC) $(NISTFLAGS) -DDILITHIUM_MODE=4 \
-	  -o $@ $< rng.c $(KECCAK_SOURCES) -lcrypto
+	  -o $@ $< rng.c $(KECCAK_SOURCES) $(LDFLAGS) -lcrypto
 
 PQCgenKAT_sign2aes: PQCgenKAT_sign.c rng.c rng.h $(AES_SOURCES) \
   $(AES_HEADERS)
 	$(CC) $(NISTFLAGS) -DDILITHIUM_MODE=2 -DDILITHIUM_USE_AES \
-	  -o $@ $< rng.c $(AES_SOURCES) -lcrypto
+	  -o $@ $< rng.c $(AES_SOURCES) $(LDFLAGS) -lcrypto
 
 PQCgenKAT_sign3aes: PQCgenKAT_sign.c rng.c rng.h $(AES_SOURCES) \
   $(AES_HEADERS)
 	$(CC) $(NISTFLAGS) -DDILITHIUM_MODE=3 -DDILITHIUM_USE_AES \
-	  -o $@ $< rng.c $(AES_SOURCES) -lcrypto
+	  -o $@ $< rng.c $(AES_SOURCES) $(LDFLAGS) -lcrypto
 
 PQCgenKAT_sign4aes: PQCgenKAT_sign.c rng.c rng.h $(AES_SOURCES) \
   $(AES_HEADERS)
 	$(CC) $(NISTFLAGS) -DDILITHIUM_MODE=4 -DDILITHIUM_USE_AES \
-	  -o $@ $< rng.c $(AES_SOURCES) -lcrypto
+	  -o $@ $< rng.c $(AES_SOURCES) $(LDFLAGS) -lcrypto
 
 clean:
 	rm -f *~ test/*~


### PR DESCRIPTION
Adding `LDFLAGS` to get around this error message:

> ld: cannot link directly with dylib/framework, your binary is not an allowed client of /usr/local/lib/libcrypto.dylib for architecture x86_64