### PR TITLE
CCI enablement

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,9 +37,7 @@ localCheckout: &localCheckout
         - run:
             name: Install dependencies
             command: |
-              scripts/git_no_checkin_in_last_day.sh || (
               pip install pytest pytest-xdist
-              )
             shell: bash.exe
         - run:
             name: Configure & Build
@@ -88,8 +86,9 @@ jobs:
         - run:
             name: Install dependencies
             command: |
-              ls -laR /usr/local/Cellar/openssl@1.1 
-              #brew update && brew install openssl@1.1 && echo 'export PATH="/usr/local/opt/openssl@1.1/bin:$PATH"' >> ~/.bash_profile && openssl version 
+              ls -la /usr/local/Cellar/openssl@1.1 
+              # OpenSSL 1.1 should already be installed -- if not:
+              # brew update && brew install openssl@1.1 && echo 'export PATH="/usr/local/Cellar/openssl@1.1/bin:$PATH"' >> ~/.bash_profile && openssl version 
         - run:
             name: Build-and-Test
             command: ./runtests.sh > test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,123 @@
+# Use the latest 2.1 version of CircleCI pipeline process engine. See: https://circleci.com/docs/2.0/configuration-reference
+version: 2.1
+orbs:
+  win: circleci/windows@2.2.0
+
+# CircleCI doesn't handle large file sets properly for local builds
+# https://github.com/CircleCI-Public/circleci-cli/issues/281#issuecomment-472808051
+localCheckout: &localCheckout
+  run: |-
+    PROJECT_PATH=$(cd ${CIRCLE_WORKING_DIRECTORY}; pwd)
+    mkdir -p ${PROJECT_PATH}
+    cd /tmp/_circleci_local_build_repo
+    git ls-files -z | xargs -0 -s 2090860 tar -c | tar -x -C ${PROJECT_PATH}
+    cp -a /tmp/_circleci_local_build_repo/.git ${PROJECT_PATH}
+
+.unixjob: &unixjob
+  docker:
+    - image: ${IMAGE}
+  steps:
+    - checkout # change this from "checkout" to "*localCheckout" when running CircleCI locally
+    - run:
+        name: Build-and-Test
+        command: source ~/.bashrc && ./runtests.sh > test-results
+    - store_artifacts:
+        path: test-results
+
+# For now, consider this sample code only; need to fill with life for Win-Testing
+.winjob: &winjob
+    executor:
+      name: win/default
+    steps:
+        - checkout
+        - run:
+           name: Install ninja
+           command: $ProgressPreference="SilentlyContinue" ; Invoke-RestMethod -Uri https://github.com/ninja-build/ninja/releases/download/v1.10.0/ninja-win.zip -Method Get -OutFile ninja.zip; Expand-Archive ninja.zip
+           shell: powershell.exe
+        - run:
+            name: Install dependencies
+            command: |
+              scripts/git_no_checkin_in_last_day.sh || (
+              pip install pytest pytest-xdist
+              )
+            shell: bash.exe
+        - run:
+            name: Configure & Build
+            command: PATH=C:\Users\circleci\project\ninja;%PATH% & call C:\PROGRA~2\MICROS~2\2019\Community\VC\Auxiliary\Build\vcvars64.bat & mkdir build & cd build & cmake -GNinja ${CONFIGURE_ARGS} .. & ninja
+            shell: cmd.exe
+
+jobs:
+  alpine-amd64:
+    <<: *unixjob
+    environment:
+      IMAGE: openquantumsafe/ci-alpine-amd64:latest
+  centos-7-amd64:
+    <<: *unixjob
+    environment:
+      IMAGE: openquantumsafe/ci-centos-7-amd64:latest
+  centos-8-amd64:
+    <<: *unixjob
+    environment:
+      IMAGE: openquantumsafe/ci-centos-8-amd64:latest
+  debian-buster-amd64:
+    <<: *unixjob
+    environment:
+      IMAGE: openquantumsafe/ci-debian-buster-amd64:latest
+  ubuntu-bionic-x86_64-gcc8:
+    <<: *unixjob
+    environment:
+      IMAGE: openquantumsafe/ci-ubuntu-bionic-x86_64:latest
+      CC: gcc-8
+  ubuntu-bionic-x86_64-clang9:
+    <<: *unixjob
+    environment:
+      IMAGE: openquantumsafe/ci-ubuntu-bionic-x86_64:latest
+      CC: clang-9
+  ubuntu-bionic-x86_64-gcc7-shared:
+    <<: *unixjob
+    environment:
+      IMAGE: openquantumsafe/ci-ubuntu-bionic-x86_64:latest
+      CC: gcc-7
+
+
+  macOS:
+    macos:
+        xcode: "11.3.0"
+    steps:
+        - checkout
+        - run:
+            name: Install dependencies
+            command: |
+              ls -laR /usr/local/Cellar/openssl@1.1 
+              #brew update && brew install openssl@1.1 && echo 'export PATH="/usr/local/opt/openssl@1.1/bin:$PATH"' >> ~/.bash_profile && openssl version 
+        - run:
+            name: Build-and-Test
+            command: ./runtests.sh > test-results
+        - store_artifacts:
+            path: test-results
+
+
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      # Only MIB has Windows credits
+      #- win-static:
+      #    filters:
+      #      branches:
+      #        only:
+      #          - /mb-.*/
+      #- win-shared:
+      #    filters:
+      #      branches:
+      #        only:
+      #          - /mb-.*/
+      - alpine-amd64
+      - centos-7-amd64
+      - centos-8-amd64
+      - debian-buster-amd64
+      - macOS
+      - ubuntu-bionic-x86_64-gcc8
+      - ubuntu-bionic-x86_64-clang9
+      - ubuntu-bionic-x86_64-gcc7-shared

--- a/avx2/Makefile
+++ b/avx2/Makefile
@@ -1,7 +1,7 @@
-CC = /usr/bin/cc
 CFLAGS += -Wall -Wextra -Wpedantic -Wmissing-prototypes -Wredundant-decls \
   -Wshadow -Wpointer-arith -march=native -mtune=native -O3 \
   -fomit-frame-pointer -flto
+LDFLAGS=
 NISTFLAGS += -Wno-unused-result -march=native -mtune=native -O3
 SOURCES = sign.c packing.c polyvec.c poly.c ntt.S invntt.S pointwise.S \
   consts.c rejsample.c reduce.S rounding.c
@@ -12,6 +12,25 @@ KECCAK_SOURCES = $(SOURCES) fips202.c fips202x4.c symmetric-shake.c \
 KECCAK_HEADERS = $(HEADERS) fips202.h fips202x4.h
 AES_SOURCES = $(SOURCES) fips202.c aes256ctr.c
 AES_HEADERS = $(HEADERS) fips202.h aes256ctr.h
+
+# a poor man's alternative to cmake
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+    CC = /usr/bin/cc
+    CFLAGS += -I/usr/local/Cellar/openssl@1.1/1.1.1d/include
+    LDFLAGS += -L/usr/local/Cellar/openssl@1.1/1.1.1d/lib
+else
+    OSID := $(shell grep ^ID= /etc/os-release)
+    ifeq ($(OSID),ID="centos")
+      CC ?= /usr/bin/cc
+      CFLAGS += -I/usr/local/ssl/include
+      LDFLAGS += -L/usr/local/ssl/lib
+      NISTFLAGS += -I/usr/local/ssl/include
+    else
+      CC = /usr/bin/cc
+    endif
+endif
+
 
 .PHONY: all shared clean
 
@@ -129,32 +148,32 @@ test/test_dilithium4aes: test/test_dilithium.c randombytes.c $(AES_SOURCES) \
 test/test_vectors2: test/test_vectors.c rng.c rng.h $(KECCAK_SOURCES) \
   $(KECCAK_HEADERS)
 	$(CC) $(NISTFLAGS) -DDILITHIUM_MODE=2 \
-	  -o $@ $< rng.c $(KECCAK_SOURCES) -lcrypto
+	  -o $@ $< rng.c $(KECCAK_SOURCES) $(LDFLAGS) -lcrypto
 
 test/test_vectors3: test/test_vectors.c rng.c rng.h $(KECCAK_SOURCES) \
   $(KECCAK_HEADERS)
 	$(CC) $(NISTFLAGS) -DDILITHIUM_MODE=3 \
-	  -o $@ $< rng.c $(KECCAK_SOURCES) -lcrypto
+	  -o $@ $< rng.c $(KECCAK_SOURCES) $(LDFLAGS) -lcrypto
 
 test/test_vectors4: test/test_vectors.c rng.c rng.h $(KECCAK_SOURCES) \
   $(KECCAK_HEADERS)
 	$(CC) $(NISTFLAGS) -DDILITHIUM_MODE=4 \
-	  -o $@ $< rng.c $(KECCAK_SOURCES) -lcrypto
+	  -o $@ $< rng.c $(KECCAK_SOURCES) $(LDFLAGS) -lcrypto
 
 test/test_vectors2aes: test/test_vectors.c rng.c rng.h $(AES_SOURCES) \
   $(AES_HEADERS)
 	$(CC) $(NISTFLAGS) -DDILITHIUM_MODE=2 -DDILITHIUM_USE_AES \
-	  -o $@ $< rng.c $(AES_SOURCES) -lcrypto
+	  -o $@ $< rng.c $(AES_SOURCES) $(LDFLAGS) -lcrypto
 
 test/test_vectors3aes: test/test_vectors.c rng.c rng.h $(AES_SOURCES) \
   $(AES_HEADERS)
 	$(CC) $(NISTFLAGS) -DDILITHIUM_MODE=3 -DDILITHIUM_USE_AES \
-	  -o $@ $< rng.c $(AES_SOURCES) -lcrypto
+	  -o $@ $< rng.c $(AES_SOURCES) $(LDFLAGS) -lcrypto
 
 test/test_vectors4aes: test/test_vectors.c rng.c rng.h $(AES_SOURCES) \
   $(AES_HEADERS)
 	$(CC) $(NISTFLAGS) -DDILITHIUM_MODE=4 -DDILITHIUM_USE_AES \
-	  -o $@ $< rng.c $(AES_SOURCES) -lcrypto
+	  -o $@ $< rng.c $(AES_SOURCES) $(LDFLAGS) -lcrypto
 
 test/test_speed2: test/test_speed.c test/speed_print.c test/speed_print.h \
   test/cpucycles.c test/cpucycles.h randombytes.c $(KECCAK_SOURCES) \
@@ -205,29 +224,29 @@ test/test_mul: test/test_mul.c randombytes.c $(KECCAK_SOURCES) \
 PQCgenKAT_sign2: PQCgenKAT_sign.c rng.c rng.h $(KECCAK_SOURCES) \
   $(KECCAK_HEADERS)
 	$(CC) $(NISTFLAGS) -DDILITHIUM_MODE=2 \
-	  -o $@ $< rng.c $(KECCAK_SOURCES) -lcrypto
+	  -o $@ $< rng.c $(KECCAK_SOURCES) $(LDFLAGS) -lcrypto
 
 PQCgenKAT_sign3: PQCgenKAT_sign.c rng.c rng.h $(KECCAK_SOURCES) \
   $(KECCAK_HEADERS)
 	$(CC) $(NISTFLAGS) -DDILITHIUM_MODE=3 \
-	  -o $@ $< rng.c $(KECCAK_SOURCES) -lcrypto
+	  -o $@ $< rng.c $(KECCAK_SOURCES) $(LDFLAGS) -lcrypto
 
 PQCgenKAT_sign4: PQCgenKAT_sign.c rng.c rng.h $(KECCAK_SOURCES) \
   $(KECCAK_HEADERS)
 	$(CC) $(NISTFLAGS) -DDILITHIUM_MODE=4 \
-	  -o $@ $< rng.c $(KECCAK_SOURCES) -lcrypto
+	  -o $@ $< rng.c $(KECCAK_SOURCES) $(LDFLAGS) -lcrypto
 
 PQCgenKAT_sign2aes: PQCgenKAT_sign.c rng.c rng.h $(AES_SOURCES) $(AES_HEADERS)
 	$(CC) $(NISTFLAGS) -DDILITHIUM_MODE=2 -DDILITHIUM_USE_AES \
-	  -o $@ $< rng.c $(AES_SOURCES) -lcrypto
+	  -o $@ $< rng.c $(AES_SOURCES) $(LDFLAGS) -lcrypto
 
 PQCgenKAT_sign3aes: PQCgenKAT_sign.c rng.c rng.h $(AES_SOURCES) $(AES_HEADERS)
 	$(CC) $(NISTFLAGS) -DDILITHIUM_MODE=3 -DDILITHIUM_USE_AES \
-	  -o $@ $< rng.c $(AES_SOURCES) -lcrypto
+	  -o $@ $< rng.c $(AES_SOURCES) $(LDFLAGS) -lcrypto
 
 PQCgenKAT_sign4aes: PQCgenKAT_sign.c rng.c rng.h $(AES_SOURCES) $(AES_HEADERS)
 	$(CC) $(NISTFLAGS) -DDILITHIUM_MODE=4 -DDILITHIUM_USE_AES \
-	  -o $@ $< rng.c $(AES_SOURCES) -lcrypto
+	  -o $@ $< rng.c $(AES_SOURCES) $(LDFLAGS) -lcrypto
 
 clean:
 	rm -f *.o *.a *.so

--- a/ref/Makefile
+++ b/ref/Makefile
@@ -1,6 +1,7 @@
 CC ?= /usr/bin/cc
 CFLAGS += -Wall -Wextra -Wpedantic -Wmissing-prototypes -Wredundant-decls \
-   -Wshadow -Wpointer-arith -march=native -mtune=native -O3
+   -Wshadow -Wpointer-arith -march=native -mtune=native -g
+LDFLAGS=
 NISTFLAGS += -Wno-unused-result -march=native -mtune=native -O3
 SOURCES = sign.c packing.c polyvec.c poly.c ntt.c reduce.c rounding.c
 HEADERS = config.h params.h api.h sign.h packing.h polyvec.h poly.h ntt.h \
@@ -10,9 +11,29 @@ KECCAK_HEADERS = $(HEADERS) fips202.h
 AES_SOURCES = $(SOURCES) fips202.c aes256ctr.c symmetric-aes.c
 AES_HEADERS = $(HEADERS) fips202.h aes256ctr.h
 
+# a poor man's alternative to cmake...dd
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+    CFLAGS += -I/usr/local/Cellar/openssl@1.1/1.1.1d/include
+    NISTFLAGS += -I/usr/local/Cellar/openssl@1.1/1.1.1d/include
+    LDFLAGS += -L/usr/local/Cellar/openssl@1.1/1.1.1d/lib
+else
+    # clang on OSX doesn't like this; alpine neither
+    OSID := $(shell grep ^ID= /etc/os-release)
+    ifneq ($(OSID),ID=alpine)
+      CFLAGS += -pg
+    endif
+    ifeq ($(OSID),ID="centos")
+      CFLAGS += -I/usr/local/ssl/include
+      NISTFLAGS += -I/usr/local/ssl/include
+      LDFLAGS += -L/usr/local/ssl/lib
+    endif
+endif
+
 .PHONY: all shared clean
 
 all: \
+  showvars \
   test/test_dilithium2 \
   test/test_dilithium3 \
   test/test_dilithium4 \
@@ -37,6 +58,9 @@ all: \
   PQCgenKAT_sign2aes \
   PQCgenKAT_sign3aes \
   PQCgenKAT_sign4aes
+
+showvars:
+	echo $(OSID) $(CFLAGS)
 
 shared: \
   libpqcrystals_dilithium2_ref.so \
@@ -111,32 +135,32 @@ test/test_dilithium4aes: test/test_dilithium.c randombytes.c $(AES_SOURCES) \
 test/test_vectors2: test/test_vectors.c rng.c rng.h $(KECCAK_SOURCES) \
   $(KECCAK_HEADERS)
 	$(CC) $(NISTFLAGS) -DDILITHIUM_MODE=2 \
-	  -o $@ $< rng.c $(KECCAK_SOURCES) -lcrypto
+	  -o $@ $< rng.c $(KECCAK_SOURCES) $(LDFLAGS) -lcrypto
 
 test/test_vectors3: test/test_vectors.c rng.c rng.h $(KECCAK_SOURCES) \
   $(KECCAK_HEADERS)
 	$(CC) $(NISTFLAGS) -DDILITHIUM_MODE=3 \
-	  -o $@ $< rng.c $(KECCAK_SOURCES) -lcrypto
+	  -o $@ $< rng.c $(KECCAK_SOURCES) $(LDFLAGS) -lcrypto
 
 test/test_vectors4: test/test_vectors.c rng.c rng.h $(KECCAK_SOURCES) \
   $(KECCAK_HEADERS)
 	$(CC) $(NISTFLAGS) -DDILITHIUM_MODE=4 \
-	  -o $@ $< rng.c $(KECCAK_SOURCES) -lcrypto
+	  -o $@ $< rng.c $(KECCAK_SOURCES) $(LDFLAGS) -lcrypto
 
 test/test_vectors2aes: test/test_vectors.c rng.c rng.h $(AES_SOURCES) \
   $(AES_HEADERS)
 	$(CC) $(NISTFLAGS) -DDILITHIUM_MODE=2 -DDILITHIUM_USE_AES \
-	  -o $@ $< rng.c $(AES_SOURCES) -lcrypto
+	  -o $@ $< rng.c $(AES_SOURCES) $(LDFLAGS) -lcrypto
 
 test/test_vectors3aes: test/test_vectors.c rng.c rng.h $(AES_SOURCES) \
   $(AES_HEADERS)
 	$(CC) $(NISTFLAGS) -DDILITHIUM_MODE=3 -DDILITHIUM_USE_AES \
-	  -o $@ $< rng.c $(AES_SOURCES) -lcrypto
+	  -o $@ $< rng.c $(AES_SOURCES) $(LDFLAGS) -lcrypto
 
 test/test_vectors4aes: test/test_vectors.c rng.c rng.h $(AES_SOURCES) \
   $(AES_HEADERS)
 	$(CC) $(NISTFLAGS) -DDILITHIUM_MODE=4 -DDILITHIUM_USE_AES \
-	  -o $@ $< rng.c $(AES_SOURCES) -lcrypto
+	  -o $@ $< rng.c $(AES_SOURCES) $(LDFLAGS) -lcrypto
 
 test/test_speed2: test/test_speed.c test/speed_print.c test/speed_print.h \
   test/cpucycles.c test/cpucycles.h randombytes.c $(KECCAK_SOURCES) \
@@ -183,32 +207,32 @@ test/test_mul: test/test_mul.c randombytes.c $(KECCAK_SOURCES) $(KECCAK_HEADERS)
 PQCgenKAT_sign2: PQCgenKAT_sign.c rng.c rng.h $(KECCAK_SOURCES) \
   $(KECCAK_HEADERS)
 	$(CC) $(NISTFLAGS) -DDILITHIUM_MODE=2 \
-	  -o $@ $< rng.c $(KECCAK_SOURCES) -lcrypto
+	  -o $@ $< rng.c $(KECCAK_SOURCES) $(LDFLAGS) -lcrypto
 
 PQCgenKAT_sign3: PQCgenKAT_sign.c rng.c rng.h $(KECCAK_SOURCES) \
   $(KECCAK_HEADERS)
 	$(CC) $(NISTFLAGS) -DDILITHIUM_MODE=3 \
-	  -o $@ $< rng.c $(KECCAK_SOURCES) -lcrypto
+	  -o $@ $< rng.c $(KECCAK_SOURCES) $(LDFLAGS) -lcrypto
 
 PQCgenKAT_sign4: PQCgenKAT_sign.c rng.c rng.h $(KECCAK_SOURCES) \
   $(KECCAK_HEADERS)
 	$(CC) $(NISTFLAGS) -DDILITHIUM_MODE=4 \
-	  -o $@ $< rng.c $(KECCAK_SOURCES) -lcrypto
+	  -o $@ $< rng.c $(KECCAK_SOURCES) $(LDFLAGS) -lcrypto
 
 PQCgenKAT_sign2aes: PQCgenKAT_sign.c rng.c rng.h $(AES_SOURCES) \
   $(AES_HEADERS)
 	$(CC) $(NISTFLAGS) -DDILITHIUM_MODE=2 -DDILITHIUM_USE_AES \
-	  -o $@ $< rng.c $(AES_SOURCES) -lcrypto
+	  -o $@ $< rng.c $(AES_SOURCES) $(LDFLAGS) -lcrypto
 
 PQCgenKAT_sign3aes: PQCgenKAT_sign.c rng.c rng.h $(AES_SOURCES) \
   $(AES_HEADERS)
 	$(CC) $(NISTFLAGS) -DDILITHIUM_MODE=3 -DDILITHIUM_USE_AES \
-	  -o $@ $< rng.c $(AES_SOURCES) -lcrypto
+	  -o $@ $< rng.c $(AES_SOURCES) $(LDFLAGS) -lcrypto
 
 PQCgenKAT_sign4aes: PQCgenKAT_sign.c rng.c rng.h $(AES_SOURCES) \
   $(AES_HEADERS)
 	$(CC) $(NISTFLAGS) -DDILITHIUM_MODE=4 -DDILITHIUM_USE_AES \
-	  -o $@ $< rng.c $(AES_SOURCES) -lcrypto
+	  -o $@ $< rng.c $(AES_SOURCES) $(LDFLAGS) -lcrypto
 
 clean:
 	rm -f *~ test/*~

--- a/ref/Makefile
+++ b/ref/Makefile
@@ -11,7 +11,7 @@ KECCAK_HEADERS = $(HEADERS) fips202.h
 AES_SOURCES = $(SOURCES) fips202.c aes256ctr.c symmetric-aes.c
 AES_HEADERS = $(HEADERS) fips202.h aes256ctr.h
 
-# a poor man's alternative to cmake...dd
+# a poor man's alternative to cmake
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
     CFLAGS += -I/usr/local/Cellar/openssl@1.1/1.1.1d/include

--- a/runtests.sh
+++ b/runtests.sh
@@ -6,5 +6,10 @@ for dir in ref avx2; do
     ./$dir/test/test_vectors$alg > tvecs$alg
     ./$dir/PQCgenKAT_sign$alg
   done
-  sha256sum -c SHA256SUMS
+  # sha256sum not guaranteed to be installed in OSX
+  if [ `uname` == "Darwin" ]; then
+     shasum -a256 -c SHA256SUMS
+  else
+     sha256sum -c SHA256SUMS
+  fi
 done


### PR DESCRIPTION
This implements #17 

It exposes a weakness in using -mnative (if AVX2 is _not_ native)...

It's a start for cross-platform testing but needs to be improved on as it relies on a UNIX shell script (see https://github.com/pq-crystals/dilithium/issues/16#issuecomment-639261587) 

