### PR TITLE
Windows build-and-test via cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,9 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 if(WIN32)
     set(CMAKE_GENERATOR_CC cl)
+    message("  In case of linkage problems be sure to select the proper architecture, e.g. via 'cmake -A x64 ..'")
+    message("  In case of runtime problems be sure to select Release config to avoid dev-dll problems, e.g. via 'msbuild ALL_BUILD.vcxproj /property:Configuration=Release'")
+    message("  In case of test problems be sure to output error messages, e.g., via 'ctest --output-on-failure -C Release'")
 else()
 include(FindUnixCommands)
 endif()
@@ -33,11 +36,15 @@ if(NOT DEFINED OPENSSL_ROOT_DIR)
         endif()
 endif()
 find_package(OpenSSL 1.1.1 REQUIRED)
+include_directories(${OPENSSL_INCLUDE_DIR})
 
 enable_testing()
 
 add_subdirectory(ref)
+# For the time being, don't build AVX2 on Win:
+if(NOT WIN32)
 add_subdirectory(avx2)
+endif()
 
 add_library(dilithium ${REF_OBJS} ${AVX2_OBJS})
 

--- a/ref/CMakeLists.txt
+++ b/ref/CMakeLists.txt
@@ -18,7 +18,6 @@ if(CMAKE_C_COMPILER_ID MATCHES "Clang")
 	add_compile_options(-Wpointer-arith)
 
 elseif(CMAKE_C_COMPILER_ID STREQUAL "GNU")
-	add_compile_options(-Werror)
 	add_compile_options(-Wall)
 	add_compile_options(-Wextra)
 	add_compile_options(-Wpedantic)

--- a/ref/CMakeLists.txt
+++ b/ref/CMakeLists.txt
@@ -7,7 +7,34 @@ set(AES_FILES aes256ctr.c)
 set(KECCAK_FILES fips202.c)
 set(AES_SRCS ${SRCS} symmetric-aes.c)
 
-add_compile_options(-Wall -Wextra -Wpedantic -Wmissing-prototypes -Wredundant-decls -Wshadow -Wpointer-arith -g)
+if(CMAKE_C_COMPILER_ID MATCHES "Clang")
+	add_compile_options(-g)
+	add_compile_options(-Wall)
+	add_compile_options(-Wextra)
+	add_compile_options(-Wpedantic)
+	add_compile_options(-Wmissing-prototypes)
+	add_compile_options(-Wredundant-decls)
+	add_compile_options(-Wshadow)
+	add_compile_options(-Wpointer-arith)
+
+elseif(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+	add_compile_options(-Werror)
+	add_compile_options(-Wall)
+	add_compile_options(-Wextra)
+	add_compile_options(-Wpedantic)
+	add_compile_options(-Wmissing-prototypes)
+	add_compile_options(-Wredundant-decls)
+	add_compile_options(-Wshadow)
+	add_compile_options(-Wpointer-arith)
+	add_compile_options(-O3)
+
+elseif(CMAKE_C_COMPILER_ID STREQUAL "MSVC")
+	# Warning C4146 is raised when a unary minus operator is applied to an
+	# unsigned type; this has nonetheless been standard and portable for as
+	# long as there has been a C standard, and we need it for constant-time
+	# computations. Thus, we disable that spurious warning.
+	add_compile_options(/wd4146)
+endif()
 
 
 # First, do libraries:
@@ -23,18 +50,20 @@ foreach(X RANGE 2 4)
    #add_test(test_dil${X}_ref test_dil${X}_ref)
    set(_REF_OBJS ${_REF_OBJS} $<TARGET_OBJECTS:dil${X}lib_ref>)
 
-   # Plain speed
+   if(NOT WIN32)
+   # Plain speed - not yet supported in Windows: TBD
    add_executable(test_speed${X}_ref ${SPEED_SRCS})
    target_compile_options(test_speed${X}_ref PUBLIC -DDILITHIUM_MODE=${X})
    target_link_libraries(test_speed${X}_ref dilithium)
    #add_test(test_speed${X}_ref test_speed${X}_ref)
+   endif()
 
    # Plain test vectors
    add_executable(test_vectors${X}_ref ${VECTOR_SRCS})
    target_compile_options(test_vectors${X}_ref PUBLIC -DDILITHIUM_MODE=${X})
    target_link_libraries(test_vectors${X}_ref PRIVATE dilithium ${OPENSSL_CRYPTO_LIBRARY})
    if (WIN32) 
-      add_test(NAME test_vectors${X}_ref COMMAND ${CMAKE_COMMAND} -E chdir $<TARGET_FILE_DIR:test_vectors${X}_ref> $ENV{ComSpec} /c "$<TARGET_FILE_NAME:test_vectors${X}_ref> > tvecs${X}")
+      add_test(NAME test_vectors${X}_ref COMMAND ${CMAKE_COMMAND} -E chdir $<TARGET_FILE_DIR:test_vectors${X}_ref> $ENV{ComSpec} /c "$<TARGET_FILE_NAME:test_vectors${X}_ref> | dos2unix > ../tvecs${X}")
    else()
       add_test(NAME test_vectors${X}_ref COMMAND sh -c "$<TARGET_FILE:test_vectors${X}_ref> > tvecs${X}")
    endif()
@@ -43,7 +72,12 @@ foreach(X RANGE 2 4)
    add_executable(PQCgenKAT_sign${X}_ref ${PQCKAT_SRCS})
    target_compile_options(PQCgenKAT_sign${X}_ref PUBLIC -DDILITHIUM_MODE=${X})
    target_link_libraries(PQCgenKAT_sign${X}_ref PRIVATE dilithium ${OPENSSL_CRYPTO_LIBRARY})
-   add_test(PQCgenKAT_sign${X}_ref PQCgenKAT_sign${X}_ref)
+   if (WIN32) 
+      # Necessary cludge to make hashes be ignorant of Windows CRLF file formatting:
+      add_test(NAME PQCgenKAT_sign${X}_ref COMMAND ${CMAKE_COMMAND} -E chdir $<TARGET_FILE_DIR:PQCgenKAT_sign${X}_ref> $ENV{ComSpec} /c "$<TARGET_FILE_NAME:PQCgenKAT_sign${X}_ref> && dos2unix -n PQCsignKAT_Dilithium${X}.rsp ../PQCsignKAT_Dilithium${X}.rsp && dos2unix -n PQCsignKAT_Dilithium${X}.req ../PQCsignKAT_Dilithium${X}.req")
+   else()
+      add_test(PQCgenKAT_sign${X}_ref PQCgenKAT_sign${X}_ref)
+   endif()
 
    # AES tests
    add_library(dil${X}aeslib_ref OBJECT ${AES_SRCS})
@@ -54,18 +88,20 @@ foreach(X RANGE 2 4)
    #add_test(test_dil${X}aes_ref test_dil${X}aes_ref)
    set(_REF_OBJS ${_REF_OBJS} $<TARGET_OBJECTS:dil${X}aeslib_ref>)
 
-   # AES speed
+   if(NOT WIN32)
+   # AES speed - not yet supported in Windows: TBD
    add_executable(test_speed${X}aes_ref ${SPEED_SRCS})
    target_compile_options(test_speed${X}aes_ref PUBLIC -DDILITHIUM_MODE=${X} -DDILITHIUM_USE_AES)
    target_link_libraries(test_speed${X}aes_ref dilithium)
    #add_test(test_speed${X}aes_ref test_speed${X}aes_ref)
+   endif()
 
    # AES test vectors
    add_executable(test_vectors${X}aes_ref ${VECTOR_SRCS})
    target_compile_options(test_vectors${X}aes_ref PUBLIC -DDILITHIUM_MODE=${X} -DDILITHIUM_USE_AES)
    target_link_libraries(test_vectors${X}aes_ref PRIVATE dilithium ${OPENSSL_CRYPTO_LIBRARY})
    if (WIN32) 
-      add_test(NAME test_vectors${X}aes_ref COMMAND ${CMAKE_COMMAND} -E chdir $<TARGET_FILE_DIR:test_vectors${X}aes_ref> $ENV{ComSpec} /c "$<TARGET_FILE_NAME:test_vectors${X}aes_ref> > tvecs${X}aes")
+      add_test(NAME test_vectors${X}aes_ref COMMAND ${CMAKE_COMMAND} -E chdir $<TARGET_FILE_DIR:test_vectors${X}aes_ref> $ENV{ComSpec} /c "$<TARGET_FILE_NAME:test_vectors${X}aes_ref> | dos2unix > ../tvecs${X}aes")
    else()
       add_test(NAME test_vectors${X}aes_ref COMMAND sh -c "$<TARGET_FILE:test_vectors${X}aes_ref> > tvecs${X}aes")
    endif()
@@ -74,7 +110,12 @@ foreach(X RANGE 2 4)
    add_executable(PQCgenKAT_sign${X}aes_ref ${PQCKAT_SRCS})
    target_compile_options(PQCgenKAT_sign${X}aes_ref PUBLIC -DDILITHIUM_MODE=${X} -DDILITHIUM_USE_AES)
    target_link_libraries(PQCgenKAT_sign${X}aes_ref PRIVATE dilithium ${OPENSSL_CRYPTO_LIBRARY})
-   add_test(PQCgenKAT_sign${X}aes_ref PQCgenKAT_sign${X}aes_ref)
+   if (WIN32) 
+      # Necessary cludge to make hashes be ignorant of Windows CRLF file formatting:
+      add_test(NAME PQCgenKAT_sign${X}aes_ref COMMAND ${CMAKE_COMMAND} -E chdir $<TARGET_FILE_DIR:PQCgenKAT_sign${X}aes_ref> $ENV{ComSpec} /c "$<TARGET_FILE_NAME:PQCgenKAT_sign${X}aes_ref> && dos2unix -n PQCsignKAT_Dilithium${X}-AES.rsp ../PQCsignKAT_Dilithium${X}-AES.rsp && dos2unix -n PQCsignKAT_Dilithium${X}-AES.req ../PQCsignKAT_Dilithium${X}-AES.req")
+   else()
+      add_test(PQCgenKAT_sign${X}aes_ref PQCgenKAT_sign${X}aes_ref)
+   endif()
 endforeach()
 
 add_test(Hashes_test_ref sha256sum -c ../../SHA256SUMS)


### PR DESCRIPTION
As discussed with @gregorseiler:
- `avx2` presently not built under Windows
- speed testing also in `ref` not built under Windows
- `dos2unix` shenenigans added to enable cmake-based testing (also) under Windows

Suggestion: perform cmake-based CI testing (also) under UNIX? 