### PR TITLE
meta.yml files directing automated OQS import

### DIFF
--- a/DILITHIUM_2_META.yml
+++ b/DILITHIUM_2_META.yml
@@ -1,0 +1,44 @@
+name: Dilithium2
+type: signature
+claimed-nist-level: 1
+length-public-key: 1184
+length-secret-key: 2800
+length-signature: 2044
+nistkat-sha256: 23b7d52a268bbd8633d139b64a1b0e3263777cb2b074f7af0a7fd315afe94d18
+testvectors-sha256: d647039ae7e1785414c64934d5ae37518f259acab95d6a6e873e9b6d3ad63dfd
+principal-submitters:
+  - Vadim Lyubashevsky
+auxiliary-submitters:
+  - Léo Ducas
+  - Eike Kiltz
+  - Tancrède Lepoint
+  - Peter Schwabe
+  - Gregor Seiler
+  - Damien Stehlé
+implementations:
+    - name: clean
+      version: https://github.com/pq-crystals/dilithium/commit/40097237d92dbff3c5c869df9dfcaa32001776c2
+      folder_name: ref
+      compile_opts: -DDILITHIUM_MODE=2 -DDILITHIUM_RANDOMIZED_SIGNING
+      signature_keypair: pqcrystals_dilithium2_ref_keypair
+      signature_signature: pqcrystals_dilithium2_ref_signature
+      signature_verify: pqcrystals_dilithium2_ref_verify
+      sources: api.h config.h params.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.c ntt.h reduce.c reduce.h rounding.c rounding.h symmetric.h symmetric-shake.c fips202.h aes256ctr.h
+
+    - name: avx2
+      version: https://github.com/pq-crystals/dilithium/commit/40097237d92dbff3c5c869df9dfcaa32001776c2
+      compile_opts: -DDILITHIUM_MODE=2 -DDILITHIUM_RANDOMIZED_SIGNING
+      signature_keypair: pqcrystals_dilithium2_avx2_keypair
+      signature_signature: pqcrystals_dilithium2_avx2_signature
+      signature_verify: pqcrystals_dilithium2_avx2_verify
+      sources: api.h config.h params.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.S ntt.h invntt.S pointwise.S consts.c consts.h reduce.S reduce.h rejsample.c rejsample.h rounding.c rounding.h symmetric.h symmetric-shake.c shuffle.inc fips202x4.h aes256ctr.h fips202.h
+      supported_platforms:
+          - architecture: x86_64
+            operating_systems:
+                - Darwin
+                - Linux
+            required_flags:
+                - avx2
+                - aes
+                - bmi
+                - popcnt

--- a/DILITHIUM_3_META.yml
+++ b/DILITHIUM_3_META.yml
@@ -1,0 +1,43 @@
+name: Dilithium3
+type: signature
+claimed-nist-level: 2
+length-public-key: 1472
+length-secret-key: 3504
+length-signature: 2701
+nistkat-sha256: 900268789819cc81b03e6384d97336b7bc700a5a9ffd5d3c993deacb6fe7f5b6
+testvectors-sha256: 35d7e51b9e4e456c68bfc5ae393d311c96005d8563eb3240a051c97f3710c45d
+principal-submitters:
+  - Vadim Lyubashevsky
+auxiliary-submitters:
+  - Léo Ducas
+  - Eike Kiltz
+  - Tancrède Lepoint
+  - Peter Schwabe
+  - Gregor Seiler
+  - Damien Stehlé
+implementations:
+    - name: clean
+      version: https://github.com/pq-crystals/dilithium/commit/40097237d92dbff3c5c869df9dfcaa32001776c2
+      folder_name: ref
+      compile_opts: -DDILITHIUM_MODE=3 -DDILITHIUM_RANDOMIZED_SIGNING
+      signature_keypair: pqcrystals_dilithium3_ref_keypair
+      signature_signature: pqcrystals_dilithium3_ref_signature
+      signature_verify: pqcrystals_dilithium3_ref_verify
+      sources: api.h config.h params.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.c ntt.h reduce.c reduce.h rounding.c rounding.h symmetric.h symmetric-shake.c fips202.h aes256ctr.h fips202.c aes256ctr.c symmetric-aes.c
+    - name: avx2
+      version: https://github.com/pq-crystals/dilithium/commit/40097237d92dbff3c5c869df9dfcaa32001776c2
+      compile_opts: -DDILITHIUM_MODE=3 -DDILITHIUM_RANDOMIZED_SIGNING
+      signature_keypair: pqcrystals_dilithium3_avx2_keypair
+      signature_signature: pqcrystals_dilithium3_avx2_signature
+      signature_verify: pqcrystals_dilithium3_avx2_verify
+      sources: api.h config.h params.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.S ntt.h invntt.S pointwise.S consts.c consts.h reduce.S reduce.h rejsample.c rejsample.h rounding.c rounding.h symmetric.h symmetric-shake.c shuffle.inc fips202x4.h aes256ctr.h fips202.h keccak4x fips202x4.c aes256ctr.c
+      supported_platforms:
+          - architecture: x86_64
+            operating_systems:
+                - Darwin
+                - Linux
+            required_flags:
+                - avx2
+                - aes
+                - bmi
+                - popcnt

--- a/DILITHIUM_4_META.yml
+++ b/DILITHIUM_4_META.yml
@@ -1,0 +1,43 @@
+name: Dilithium4
+type: signature
+claimed-nist-level: 3
+length-public-key: 1760
+length-secret-key: 3856
+length-signature: 3366
+nistkat-sha256: 87844f967b4340d60dc4d83aac0f1d3a244fa8f9490017f72fd4969bba168f88
+testvectors-sha256: 91087880c84678bf66008d843e7fa1ab5231114a8ca9e9e36c41065f14172af2
+principal-submitters:
+  - Vadim Lyubashevsky
+auxiliary-submitters:
+  - Léo Ducas
+  - Eike Kiltz
+  - Tancrède Lepoint
+  - Peter Schwabe
+  - Gregor Seiler
+  - Damien Stehlé
+implementations:
+    - name: clean
+      version: https://github.com/pq-crystals/dilithium/commit/40097237d92dbff3c5c869df9dfcaa32001776c2
+      folder_name: ref
+      compile_opts: -DDILITHIUM_MODE=4 -DDILITHIUM_RANDOMIZED_SIGNING
+      signature_keypair: pqcrystals_dilithium4_ref_keypair
+      signature_signature: pqcrystals_dilithium4_ref_signature
+      signature_verify: pqcrystals_dilithium4_ref_verify
+      sources: api.h config.h params.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.c ntt.h reduce.c reduce.h rounding.c rounding.h symmetric.h symmetric-shake.c fips202.h aes256ctr.h
+    - name: avx2
+      version: https://github.com/pq-crystals/dilithium/commit/40097237d92dbff3c5c869df9dfcaa32001776c2
+      compile_opts: -DDILITHIUM_MODE=4 -DDILITHIUM_RANDOMIZED_SIGNING
+      signature_keypair: pqcrystals_dilithium4_avx2_keypair
+      signature_signature: pqcrystals_dilithium4_avx2_signature
+      signature_verify: pqcrystals_dilithium4_avx2_verify
+      sources: api.h config.h params.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.S ntt.h invntt.S pointwise.S consts.c consts.h reduce.S reduce.h rejsample.c rejsample.h rounding.c rounding.h symmetric.h symmetric-shake.c shuffle.inc fips202x4.h aes256ctr.h fips202.h
+      supported_platforms:
+          - architecture: x86_64
+            operating_systems:
+                - Darwin
+                - Linux
+            required_flags:
+                - avx2
+                - bmi
+                - aes
+                - popcnt


### PR DESCRIPTION
These files allow `pqcrystals` to determine/drive how/what downstream repositories, particularly [OQS](https://github.com/open-quantum-safe/liboqs), imports from this repository. 

These files are designed very much like the [`PQClean`](https://github.com/PQClean/PQClean) META.yml files and thus may also ease automated integration to that repository and [its downstreams](https://github.com/PQClean/PQClean#projects-integrating-pqclean-distributed-source-code) if and when so desired (future work).

Conceptually missing is a separation into common and algorithm specific files (pursuant #21). Thus, the common files are currently all concentrated in the `DILITHIUM_3_META.yml`. This will cause downstream problems if a `liboqs` build of DILITHIUM4 without DILITHIUM3 is requested. At this time (prior to NIST round 3 decision, missing implementation of #21, missing integration with `Kyber` common code) this is considered an acceptable limitation.