### PR TITLE
DIL AES not supported downstream; file removed

### DIFF
--- a/DILITHIUM_2_META.yml
+++ b/DILITHIUM_2_META.yml
@@ -23,7 +23,7 @@ implementations:
       signature_keypair: pqcrystals_dilithium2_ref_keypair
       signature_signature: pqcrystals_dilithium2_ref_signature
       signature_verify: pqcrystals_dilithium2_ref_verify
-      sources: LICENSE api.h config.h params.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.c ntt.h reduce.c reduce.h rounding.c rounding.h symmetric.h symmetric-shake.c fips202.h aes256ctr.h
+      sources: LICENSE api.h config.h params.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.c ntt.h reduce.c reduce.h rounding.c rounding.h symmetric.h symmetric-shake.c fips202.h
 
     - name: avx2
       version: https://github.com/pq-crystals/dilithium/commit/40097237d92dbff3c5c869df9dfcaa32001776c2
@@ -31,7 +31,7 @@ implementations:
       signature_keypair: pqcrystals_dilithium2_avx2_keypair
       signature_signature: pqcrystals_dilithium2_avx2_signature
       signature_verify: pqcrystals_dilithium2_avx2_verify
-      sources: LICENSE api.h config.h params.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.S ntt.h invntt.S pointwise.S consts.c consts.h reduce.S reduce.h rejsample.c rejsample.h rounding.c rounding.h symmetric.h symmetric-shake.c shuffle.inc fips202x4.h aes256ctr.h fips202.h
+      sources: LICENSE api.h config.h params.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.S ntt.h invntt.S pointwise.S consts.c consts.h reduce.S reduce.h rejsample.c rejsample.h rounding.c rounding.h symmetric.h symmetric-shake.c shuffle.inc fips202x4.h fips202.h
       supported_platforms:
           - architecture: x86_64
             operating_systems:

--- a/DILITHIUM_3_META.yml
+++ b/DILITHIUM_3_META.yml
@@ -23,7 +23,7 @@ implementations:
       signature_keypair: pqcrystals_dilithium3_ref_keypair
       signature_signature: pqcrystals_dilithium3_ref_signature
       signature_verify: pqcrystals_dilithium3_ref_verify
-      sources: LICENSE api.h config.h params.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.c ntt.h reduce.c reduce.h rounding.c rounding.h symmetric.h symmetric-shake.c fips202.h aes256ctr.h fips202.c aes256ctr.c symmetric-aes.c
+      sources: LICENSE api.h config.h params.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.c ntt.h reduce.c reduce.h rounding.c rounding.h symmetric.h symmetric-shake.c fips202.h aes256ctr.h fips202.c aes256ctr.c
     - name: avx2
       version: https://github.com/pq-crystals/dilithium/commit/40097237d92dbff3c5c869df9dfcaa32001776c2
       compile_opts: -DDILITHIUM_MODE=3 -DDILITHIUM_RANDOMIZED_SIGNING

--- a/DILITHIUM_3_META.yml
+++ b/DILITHIUM_3_META.yml
@@ -23,14 +23,14 @@ implementations:
       signature_keypair: pqcrystals_dilithium3_ref_keypair
       signature_signature: pqcrystals_dilithium3_ref_signature
       signature_verify: pqcrystals_dilithium3_ref_verify
-      sources: LICENSE api.h config.h params.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.c ntt.h reduce.c reduce.h rounding.c rounding.h symmetric.h symmetric-shake.c fips202.h aes256ctr.h fips202.c aes256ctr.c
+      sources: LICENSE api.h config.h params.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.c ntt.h reduce.c reduce.h rounding.c rounding.h symmetric.h symmetric-shake.c fips202.h fips202.c
     - name: avx2
       version: https://github.com/pq-crystals/dilithium/commit/40097237d92dbff3c5c869df9dfcaa32001776c2
       compile_opts: -DDILITHIUM_MODE=3 -DDILITHIUM_RANDOMIZED_SIGNING
       signature_keypair: pqcrystals_dilithium3_avx2_keypair
       signature_signature: pqcrystals_dilithium3_avx2_signature
       signature_verify: pqcrystals_dilithium3_avx2_verify
-      sources: LICENSE api.h config.h params.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.S ntt.h invntt.S pointwise.S consts.c consts.h reduce.S reduce.h rejsample.c rejsample.h rounding.c rounding.h symmetric.h symmetric-shake.c shuffle.inc fips202x4.h aes256ctr.h fips202.h keccak4x fips202x4.c aes256ctr.c
+      sources: LICENSE api.h config.h params.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.S ntt.h invntt.S pointwise.S consts.c consts.h reduce.S reduce.h rejsample.c rejsample.h rounding.c rounding.h symmetric.h symmetric-shake.c shuffle.inc fips202x4.h fips202.h keccak4x fips202x4.c
       supported_platforms:
           - architecture: x86_64
             operating_systems:

--- a/DILITHIUM_4_META.yml
+++ b/DILITHIUM_4_META.yml
@@ -23,14 +23,14 @@ implementations:
       signature_keypair: pqcrystals_dilithium4_ref_keypair
       signature_signature: pqcrystals_dilithium4_ref_signature
       signature_verify: pqcrystals_dilithium4_ref_verify
-      sources: LICENSE api.h config.h params.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.c ntt.h reduce.c reduce.h rounding.c rounding.h symmetric.h symmetric-shake.c fips202.h aes256ctr.h
+      sources: LICENSE api.h config.h params.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.c ntt.h reduce.c reduce.h rounding.c rounding.h symmetric.h symmetric-shake.c fips202.h
     - name: avx2
       version: https://github.com/pq-crystals/dilithium/commit/40097237d92dbff3c5c869df9dfcaa32001776c2
       compile_opts: -DDILITHIUM_MODE=4 -DDILITHIUM_RANDOMIZED_SIGNING
       signature_keypair: pqcrystals_dilithium4_avx2_keypair
       signature_signature: pqcrystals_dilithium4_avx2_signature
       signature_verify: pqcrystals_dilithium4_avx2_verify
-      sources: LICENSE api.h config.h params.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.S ntt.h invntt.S pointwise.S consts.c consts.h reduce.S reduce.h rejsample.c rejsample.h rounding.c rounding.h symmetric.h symmetric-shake.c shuffle.inc fips202x4.h aes256ctr.h fips202.h
+      sources: LICENSE api.h config.h params.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.S ntt.h invntt.S pointwise.S consts.c consts.h reduce.S reduce.h rejsample.c rejsample.h rounding.c rounding.h symmetric.h symmetric-shake.c shuffle.inc fips202x4.h fips202.h
       supported_platforms:
           - architecture: x86_64
             operating_systems:


### PR DESCRIPTION
Namespace error when importing to liboqs: Dilithium AES not supported in downstream: One file less to copy.

Alternative: #ifdef function `dilithium_aes256ctr_init` in the same way as in `symmetric.h` with `#ifdef DILITHIUM_USE_AES`