### PR TITLE
brings import META.ymls in line with downstream conventions

### DIFF
--- a/DILITHIUM_2_META.yml
+++ b/DILITHIUM_2_META.yml
@@ -40,5 +40,5 @@ implementations:
             required_flags:
                 - avx2
                 - aes
-                - bmi
+                - bmi1
                 - popcnt

--- a/DILITHIUM_3_META.yml
+++ b/DILITHIUM_3_META.yml
@@ -39,5 +39,5 @@ implementations:
             required_flags:
                 - avx2
                 - aes
-                - bmi
+                - bmi1
                 - popcnt

--- a/DILITHIUM_4_META.yml
+++ b/DILITHIUM_4_META.yml
@@ -38,6 +38,6 @@ implementations:
                 - Linux
             required_flags:
                 - avx2
-                - bmi
+                - bmi1
                 - aes
                 - popcnt


### PR DESCRIPTION
Both PQClean and OpenQuantumSafe (begin to) use "bmi1" instead of "bmi" to refer to this CPU feature. This PR thus eases import of Dilithium to these repos.