### PR TITLE
fixes #31 - undefined behaviour in AVX2 version

### DIFF
--- a/avx2/rounding.c
+++ b/avx2/rounding.c
@@ -16,7 +16,7 @@
 *              - const uint32_t *a: input array of length N
 *
 **************************************************/
-void power2round_avx(uint32_t * restrict a1, uint32_t * restrict a0, const uint32_t * restrict a)
+void power2round_avx(uint32_t *a1, uint32_t *a0, const uint32_t *a)
 {
   unsigned int i;
   __m256i f,f0,f1;
@@ -50,7 +50,7 @@ void power2round_avx(uint32_t * restrict a1, uint32_t * restrict a0, const uint3
 *              - const uint32_t *a: input array of length N
 *
 **************************************************/
-void decompose_avx(uint32_t * restrict a1, uint32_t * restrict a0, const uint32_t * restrict a)
+void decompose_avx(uint32_t *a1, uint32_t *a0, const uint32_t *a)
 {
   unsigned int i;
   __m256i f,f0,f1,t0,t1;
@@ -133,7 +133,7 @@ unsigned int make_hint_avx(uint32_t * restrict h, const uint32_t * restrict a0, 
 *              - const uint32_t *a: input array of length N with hint bits
 *
 **************************************************/
-void use_hint_avx(uint32_t * restrict b, const uint32_t * restrict a, const uint32_t * restrict hint) {
+void use_hint_avx(uint32_t *b, const uint32_t *a, const uint32_t *hint) {
   unsigned int i;
   __attribute__((aligned(32)))
   uint32_t a0[N];


### PR DESCRIPTION
restrict keyword caused undefined compiler output since referenced
objects are overlapping in memory.

e.g, for 
https://github.com/pq-crystals/dilithium/blob/497a98bc7efe48cb0d18fd20d6d9a4b5629406ef/avx2/sign.c#L159
`a1` and `a` in `power2round_avx()` point to the same object `t1`.