### PR TITLE
Preparing automatic pull for liboqs.

### DIFF
--- a/Dilithium2-AES_META.yml
+++ b/Dilithium2-AES_META.yml
@@ -4,7 +4,7 @@ claimed-nist-level: 2
 length-public-key: 1312
 length-secret-key: 2544
 length-signature: 2420
-nistkat-sha256: 0c1e2e996ba8d7a09b4f3ca1e2d1152c951785845afb572b8a2a027c3daa1bd6
+nistkat-sha256: 23972a0a5f1f32781aa11fa57d9994ddd53c1bbcc732967f61d9d9aaef01c492
 testvectors-sha256: 691b9541f65fd2dfacad28c360ebd2091cea7eecb7533ffd807a4037eb21772a
 principal-submitters:
   - Vadim Lyubashevsky
@@ -17,21 +17,20 @@ auxiliary-submitters:
   - Damien Stehlé
 implementations:
   - name: ref
-    version: https://github.com/pq-crystals/dilithium/commit/55a623c444b9f7fd036cab11fb8f2237727fe556
+    version: https://github.com/pq-crystals/dilithium/commit/1e63a1e880401166f105ab44ec67464c9714a315
     folder_name: ref
     compile_opts: -DDILITHIUM_MODE=2 -DDILITHIUM_USE_AES
     signature_keypair: pqcrystals_dilithium2aes_ref_keypair
     signature_signature: pqcrystals_dilithium2aes_ref_signature
     signature_verify: pqcrystals_dilithium2aes_ref_verify
-    sources: api.h config.h params.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.c ntt.h reduce.c reduce.h rounding.c rounding.h symmetric.h symmetric-aes.c
-
+    sources: api.h config.h params.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.c ntt.h reduce.c reduce.h rounding.c rounding.h symmetric.h fips202.h symmetric-aes.c aes256ctr.h aes256ctr.c
   - name: avx2
-    version: https://github.com/pq-crystals/dilithium/commit/55a623c444b9f7fd036cab11fb8f2237727fe556
+    version: https://github.com/pq-crystals/dilithium/commit/1e63a1e880401166f105ab44ec67464c9714a315
     compile_opts: -DDILITHIUM_MODE=2 -DDILITHIUM_USE_AES
     signature_keypair: pqcrystals_dilithium2aes_avx2_keypair
     signature_signature: pqcrystals_dilithium2aes_avx2_signature
     signature_verify: pqcrystals_dilithium2aes_avx2_verify
-    sources: api.h config.h params.h align.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.S invntt.S pointwise.S ntt.h shuffle.S shuffle.inc consts.c consts.h reduce.S reduce.h rejsample.c rejsample.h rounding.c rounding.h symmetric.h symmetric-aes.c
+    sources: api.h config.h params.h align.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.S invntt.S pointwise.S ntt.h shuffle.S shuffle.inc consts.c consts.h rejsample.c rejsample.h rounding.c rounding.h symmetric.h fips202.h aes256ctr.h aes256ctr.c
     supported_platforms:
       - architecture: x86_64
         operating_systems:

--- a/Dilithium2_META.yml
+++ b/Dilithium2_META.yml
@@ -4,7 +4,7 @@ claimed-nist-level: 2
 length-public-key: 1312
 length-secret-key: 2544
 length-signature: 2420
-nistkat-sha256: 9b16411bf7334b323e9959a2d4c10813b9e5123658240c8c54564a9cbfcbff0f
+nistkat-sha256: 9c636528bf81c03df6ad8f9471cb1b4d9097d66af825d4f60b7ff0d941ca4d37
 testvectors-sha256: e0dc8c8ace688e43a25fca7fe095030023315a3531c7b526ed80be2338f2245f
 principal-submitters:
   - Vadim Lyubashevsky
@@ -17,26 +17,25 @@ auxiliary-submitters:
   - Damien Stehlé
 implementations:
 - name: ref
-  version: https://github.com/pq-crystals/dilithium/commit/55a623c444b9f7fd036cab11fb8f2237727fe556
+  version: https://github.com/pq-crystals/dilithium/commit/1e63a1e880401166f105ab44ec67464c9714a315
   folder_name: ref
   compile_opts: -DDILITHIUM_MODE=2
-    signature_keypair: pqcrystals_dilithium2_ref_keypair
-    signature_signature: pqcrystals_dilithium2_ref_signature
-    signature_verify: pqcrystals_dilithium2_ref_verify
-    sources: api.h config.h params.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.c ntt.h reduce.c reduce.h rounding.c rounding.h symmetric.h symmetric-shake.c
-
-  - name: avx2
-    version: https://github.com/pq-crystals/dilithium/commit/55a623c444b9f7fd036cab11fb8f2237727fe556
-    compile_opts: -DDILITHIUM_MODE=2
-    signature_keypair: pqcrystals_dilithium2_avx2_keypair
-    signature_signature: pqcrystals_dilithium2_avx2_signature
-    signature_verify: pqcrystals_dilithium2_avx2_verify
-    sources: api.h config.h params.h align.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.S invntt.S pointwise.S ntt.h shuffle.S shuffle.inc consts.c consts.h reduce.S reduce.h rejsample.c rejsample.h rounding.c rounding.h symmetric.h symmetric-shake.c
-    supported_platforms:
-      - architecture: x86_64
-        operating_systems:
-          - Darwin
-          - Linux
-        required_flags:
-          - avx2
-          - popcnt
+  signature_keypair: pqcrystals_dilithium2_ref_keypair
+  signature_signature: pqcrystals_dilithium2_ref_signature
+  signature_verify: pqcrystals_dilithium2_ref_verify
+  sources: api.h config.h params.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.c ntt.h reduce.c reduce.h rounding.c rounding.h symmetric.h fips202.h fips202.c symmetric-shake.c
+- name: avx2
+  version: https://github.com/pq-crystals/dilithium/commit/1e63a1e880401166f105ab44ec67464c9714a315
+  compile_opts: -DDILITHIUM_MODE=2
+  signature_keypair: pqcrystals_dilithium2_avx2_keypair
+  signature_signature: pqcrystals_dilithium2_avx2_signature
+  signature_verify: pqcrystals_dilithium2_avx2_verify
+  sources: api.h config.h params.h align.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.S invntt.S pointwise.S ntt.h shuffle.S shuffle.inc consts.c consts.h rejsample.c rejsample.h rounding.c rounding.h symmetric.h fips202.h fips202.c fips202x4.h fips202x4.c f1600x4.S symmetric-shake.c
+  supported_platforms:
+    - architecture: x86_64
+      operating_systems:
+        - Darwin
+        - Linux
+      required_flags:
+        - avx2
+        - popcnt

--- a/Dilithium3-AES_META.yml
+++ b/Dilithium3-AES_META.yml
@@ -4,7 +4,7 @@ claimed-nist-level: 3
 length-public-key: 1952
 length-secret-key: 4016
 length-signature: 3293
-nistkat-sha256: 8aaae01ec87bbff52354f48fdad2d66234cd3ea62dbe91c30cc6d0a0f677c870
+nistkat-sha256: c1519093239804f90d1c9386e2a95b42b45dc65cbdc7c1dd777fe27de3840517
 testvectors-sha256: d5a912bd32570d907bc8b186449912259be0d0cf29cae60ff311954aa5ca06d5
 principal-submitters:
   - Vadim Lyubashevsky
@@ -17,21 +17,20 @@ auxiliary-submitters:
   - Damien Stehlé
 implementations:
   - name: ref
-    version: https://github.com/pq-crystals/dilithium/commit/55a623c444b9f7fd036cab11fb8f2237727fe556
+    version: https://github.com/pq-crystals/dilithium/commit/1e63a1e880401166f105ab44ec67464c9714a315
     folder_name: ref
     compile_opts: -DDILITHIUM_MODE=3 -DDILITHIUM_USE_AES
     signature_keypair: pqcrystals_dilithium3aes_ref_keypair
     signature_signature: pqcrystals_dilithium3aes_ref_signature
     signature_verify: pqcrystals_dilithium3aes_ref_verify
-    sources: api.h config.h params.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.c ntt.h reduce.c reduce.h rounding.c rounding.h symmetric.h symmetric-aes.c
-
+    sources: api.h config.h params.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.c ntt.h reduce.c reduce.h rounding.c rounding.h symmetric.h fips202.h symmetric-aes.c aes256ctr.h aes256ctr.c
   - name: avx2
-    version: https://github.com/pq-crystals/dilithium/commit/55a623c444b9f7fd036cab11fb8f2237727fe556
+    version: https://github.com/pq-crystals/dilithium/commit/1e63a1e880401166f105ab44ec67464c9714a315
     compile_opts: -DDILITHIUM_MODE=3 -DDILITHIUM_USE_AES
     signature_keypair: pqcrystals_dilithium3aes_avx2_keypair
     signature_signature: pqcrystals_dilithium3aes_avx2_signature
     signature_verify: pqcrystals_dilithium3aes_avx2_verify
-    sources: api.h config.h params.h align.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.S invntt.S pointwise.S ntt.h shuffle.S shuffle.inc consts.c consts.h reduce.S reduce.h rejsample.c rejsample.h rounding.c rounding.h symmetric.h symmetric-aes.c
+    sources: api.h config.h params.h align.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.S invntt.S pointwise.S ntt.h shuffle.S shuffle.inc consts.c consts.h rejsample.c rejsample.h rounding.c rounding.h symmetric.h fips202.h aes256ctr.h aes256ctr.c
     supported_platforms:
       - architecture: x86_64
         operating_systems:

--- a/Dilithium3_META.yml
+++ b/Dilithium3_META.yml
@@ -4,7 +4,7 @@ claimed-nist-level: 3
 length-public-key: 1952
 length-secret-key: 4016
 length-signature: 3293
-nistkat-sha256: 023766a8bd0830e4b1d69a04e1b76697f2a03e2f53d6e127fbccfc55bfb7c1f5
+nistkat-sha256: d0d4bb6945e14206d17b52f8a395d5a750ec8a73f2ea06b9f1cd226d225a9bfb
 testvectors-sha256: c73f18b1b06ef2cb6263c5e6a5b48fb180d187a0778d54a608d9662e19662012
 principal-submitters:
   - Vadim Lyubashevsky
@@ -17,21 +17,20 @@ auxiliary-submitters:
   - Damien Stehlé
 implementations:
   - name: ref
-    version: https://github.com/pq-crystals/dilithium/commit/55a623c444b9f7fd036cab11fb8f2237727fe556
+    version: https://github.com/pq-crystals/dilithium/commit/1e63a1e880401166f105ab44ec67464c9714a315
     folder_name: ref
     compile_opts: -DDILITHIUM_MODE=3
     signature_keypair: pqcrystals_dilithium3_ref_keypair
     signature_signature: pqcrystals_dilithium3_ref_signature
     signature_verify: pqcrystals_dilithium3_ref_verify
-    sources: api.h config.h params.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.c ntt.h reduce.c reduce.h rounding.c rounding.h symmetric.h symmetric-shake.c
-
+    sources: api.h config.h params.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.c ntt.h reduce.c reduce.h rounding.c rounding.h symmetric.h fips202.h fips202.c symmetric-shake.c
   - name: avx2
-    version: https://github.com/pq-crystals/dilithium/commit/55a623c444b9f7fd036cab11fb8f2237727fe556
+    version: https://github.com/pq-crystals/dilithium/commit/1e63a1e880401166f105ab44ec67464c9714a315
     compile_opts: -DDILITHIUM_MODE=3
     signature_keypair: pqcrystals_dilithium3_avx2_keypair
     signature_signature: pqcrystals_dilithium3_avx2_signature
     signature_verify: pqcrystals_dilithium3_avx2_verify
-    sources: api.h config.h params.h align.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.S invntt.S pointwise.S ntt.h shuffle.S shuffle.inc consts.c consts.h reduce.S reduce.h rejsample.c rejsample.h rounding.c rounding.h symmetric.h symmetric-shake.c
+    sources: api.h config.h params.h align.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.S invntt.S pointwise.S ntt.h shuffle.S shuffle.inc consts.c consts.h rejsample.c rejsample.h rounding.c rounding.h symmetric.h fips202.h fips202.c fips202x4.h fips202x4.c f1600x4.S symmetric-shake.c
     supported_platforms:
       - architecture: x86_64
         operating_systems:

--- a/Dilithium5-AES_META.yml
+++ b/Dilithium5-AES_META.yml
@@ -4,7 +4,7 @@ claimed-nist-level: 5
 length-public-key: 2592
 length-secret-key: 4880
 length-signature: 4595
-nistkat-sha256: 87ebb2cf030c5f7b5c0d6301647ae16ffa28518811ab4ecb0446c0f89ca51f15
+nistkat-sha256: 882d5050d6289875cbaa3bd920ec60ff3e2895257cbe8f76ed9d3735daa188c6
 testvectors-sha256: 23d83c4df50e8af9765b4a7323389a6baa75772e144ba4f5bafb5cea5da5c0bb
 principal-submitters:
   - Vadim Lyubashevsky
@@ -17,21 +17,20 @@ auxiliary-submitters:
   - Damien Stehlé
 implementations:
   - name: ref
-    version: https://github.com/pq-crystals/dilithium/commit/55a623c444b9f7fd036cab11fb8f2237727fe556
+    version: https://github.com/pq-crystals/dilithium/commit/1e63a1e880401166f105ab44ec67464c9714a315
     folder_name: ref
     compile_opts: -DDILITHIUM_MODE=5 -DDILITHIUM_USE_AES
     signature_keypair: pqcrystals_dilithium5aes_ref_keypair
     signature_signature: pqcrystals_dilithium5aes_ref_signature
     signature_verify: pqcrystals_dilithium5aes_ref_verify
-    sources: api.h config.h params.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.c ntt.h reduce.c reduce.h rounding.c rounding.h symmetric.h symmetric-aes.c
-
+    sources: api.h config.h params.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.c ntt.h reduce.c reduce.h rounding.c rounding.h symmetric.h fips202.h symmetric-aes.c aes256ctr.h aes256ctr.c
   - name: avx2
-    version: https://github.com/pq-crystals/dilithium/commit/55a623c444b9f7fd036cab11fb8f2237727fe556
+    version: https://github.com/pq-crystals/dilithium/commit/1e63a1e880401166f105ab44ec67464c9714a315
     compile_opts: -DDILITHIUM_MODE=5 -DDILITHIUM_USE_AES
     signature_keypair: pqcrystals_dilithium5aes_avx2_keypair
     signature_signature: pqcrystals_dilithium5aes_avx2_signature
     signature_verify: pqcrystals_dilithium5aes_avx2_verify
-    sources: api.h config.h params.h align.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.S invntt.S pointwise.S ntt.h shuffle.S shuffle.inc consts.c consts.h reduce.S reduce.h rejsample.c rejsample.h rounding.c rounding.h symmetric.h symmetric-aes.c
+    sources: api.h config.h params.h align.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.S invntt.S pointwise.S ntt.h shuffle.S shuffle.inc consts.c consts.h rejsample.c rejsample.h rounding.c rounding.h symmetric.h fips202.h aes256ctr.h aes256ctr.c
     supported_platforms:
       - architecture: x86_64
         operating_systems:

--- a/Dilithium5_META.yml
+++ b/Dilithium5_META.yml
@@ -4,7 +4,7 @@ claimed-nist-level: 5
 length-public-key: 2592
 length-secret-key: 4880
 length-signature: 4595
-nistkat-sha256: 1ee33f50a6faf2d8d98916639a3b9f1bee6c0579d129d57c2ec3720ce95a5b1d
+nistkat-sha256: 1d1ee6fb14b864bcc564ad9c416593b2ee1bf93cd65dfe70d9e400bc66be3229
 testvectors-sha256: 4801a29b7d5979422d1a0ad39e26bfb8b7af60ef46f494e2ed4db3d406cfa2ce
 principal-submitters:
   - Vadim Lyubashevsky
@@ -17,21 +17,20 @@ auxiliary-submitters:
   - Damien Stehlé
 implementations:
   - name: ref
-    version: https://github.com/pq-crystals/dilithium/commit/55a623c444b9f7fd036cab11fb8f2237727fe556
+    version: https://github.com/pq-crystals/dilithium/commit/1e63a1e880401166f105ab44ec67464c9714a315
     folder_name: ref
     compile_opts: -DDILITHIUM_MODE=5
     signature_keypair: pqcrystals_dilithium5_ref_keypair
     signature_signature: pqcrystals_dilithium5_ref_signature
     signature_verify: pqcrystals_dilithium5_ref_verify
-    sources: api.h config.h params.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.c ntt.h reduce.c reduce.h rounding.c rounding.h symmetric.h symmetric-shake.c
-
+    sources: api.h config.h params.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.c ntt.h reduce.c reduce.h rounding.c rounding.h symmetric.h fips202.h fips202.c symmetric-shake.c
   - name: avx2
-    version: https://github.com/pq-crystals/dilithium/commit/55a623c444b9f7fd036cab11fb8f2237727fe556
+    version: https://github.com/pq-crystals/dilithium/commit/1e63a1e880401166f105ab44ec67464c9714a315
     compile_opts: -DDILITHIUM_MODE=5
     signature_keypair: pqcrystals_dilithium5_avx2_keypair
     signature_signature: pqcrystals_dilithium5_avx2_signature
     signature_verify: pqcrystals_dilithium5_avx2_verify
-    sources: api.h config.h params.h align.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.S invntt.S pointwise.S ntt.h shuffle.S shuffle.inc consts.c consts.h reduce.S reduce.h rejsample.c rejsample.h rounding.c rounding.h symmetric.h symmetric-shake.c
+    sources: api.h config.h params.h align.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.S invntt.S pointwise.S ntt.h shuffle.S shuffle.inc consts.c consts.h rejsample.c rejsample.h rounding.c rounding.h symmetric.h fips202.h fips202.c fips202x4.h fips202x4.c f1600x4.S symmetric-shake.c
     supported_platforms:
       - architecture: x86_64
         operating_systems:

--- a/avx2/Makefile
+++ b/avx2/Makefile
@@ -45,11 +45,11 @@ shared: \
   libpqcrystals_dilithium2aes_avx2.so \
   libpqcrystals_dilithium3aes_avx2.so \
   libpqcrystals_dilithium5aes_avx2.so \
-  libpqcrystals_fips202_ref.so \
+  libpqcrystals_fips202_avx2.so \
   libpqcrystals_fips202x4_avx2.so \
   libpqcrystals_aes256ctr_avx2.so
 
-libpqcrystals_fips202_ref.so: fips202.c fips202.h
+libpqcrystals_fips202_avx2.so: fips202.c fips202.h
 	$(CC) -shared -fPIC $(CFLAGS) -o $@ $<
 
 libpqcrystals_fips202x4_avx2.so: fips202x4.c fips202x4.h f1600x4.S

--- a/avx2/fips202.h
+++ b/avx2/fips202.h
@@ -1,1 +1,57 @@
-../ref/fips202.h
+#ifndef FIPS202_H
+#define FIPS202_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define SHAKE128_RATE 168
+#define SHAKE256_RATE 136
+#define SHA3_256_RATE 136
+#define SHA3_512_RATE 72
+
+#define FIPS202_NAMESPACE(s) pqcrystals_fips202_avx2_##s
+
+typedef struct {
+  uint64_t s[25];
+  unsigned int pos;
+} keccak_state;
+
+#define KeccakF_RoundConstants FIPS202_NAMESPACE(KeccakF_RoundConstants)
+extern const uint64_t KeccakF_RoundConstants[];
+
+#define shake128_init FIPS202_NAMESPACE(shake128_init)
+void shake128_init(keccak_state *state);
+#define shake128_absorb FIPS202_NAMESPACE(shake128_absorb)
+void shake128_absorb(keccak_state *state, const uint8_t *in, size_t inlen);
+#define shake128_finalize FIPS202_NAMESPACE(shake128_finalize)
+void shake128_finalize(keccak_state *state);
+#define shake128_squeeze FIPS202_NAMESPACE(shake128_squeeze)
+void shake128_squeeze(uint8_t *out, size_t outlen, keccak_state *state);
+#define shake128_absorb_once FIPS202_NAMESPACE(shake128_absorb_once)
+void shake128_absorb_once(keccak_state *state, const uint8_t *in, size_t inlen);
+#define shake128_squeezeblocks FIPS202_NAMESPACE(shake128_squeezeblocks)
+void shake128_squeezeblocks(uint8_t *out, size_t nblocks, keccak_state *state);
+
+#define shake256_init FIPS202_NAMESPACE(shake256_init)
+void shake256_init(keccak_state *state);
+#define shake256_absorb FIPS202_NAMESPACE(shake256_absorb)
+void shake256_absorb(keccak_state *state, const uint8_t *in, size_t inlen);
+#define shake256_finalize FIPS202_NAMESPACE(shake256_finalize)
+void shake256_finalize(keccak_state *state);
+#define shake256_squeeze FIPS202_NAMESPACE(shake256_squeeze)
+void shake256_squeeze(uint8_t *out, size_t outlen, keccak_state *state);
+#define shake256_absorb_once FIPS202_NAMESPACE(shake256_absorb_once)
+void shake256_absorb_once(keccak_state *state, const uint8_t *in, size_t inlen);
+#define shake256_squeezeblocks FIPS202_NAMESPACE(shake256_squeezeblocks)
+void shake256_squeezeblocks(uint8_t *out, size_t nblocks,  keccak_state *state);
+
+#define shake128 FIPS202_NAMESPACE(shake128)
+void shake128(uint8_t *out, size_t outlen, const uint8_t *in, size_t inlen);
+#define shake256 FIPS202_NAMESPACE(shake256)
+void shake256(uint8_t *out, size_t outlen, const uint8_t *in, size_t inlen);
+#define sha3_256 FIPS202_NAMESPACE(sha3_256)
+void sha3_256(uint8_t h[32], const uint8_t *in, size_t inlen);
+#define sha3_512 FIPS202_NAMESPACE(sha3_512)
+void sha3_512(uint8_t h[64], const uint8_t *in, size_t inlen);
+
+#endif


### PR DESCRIPTION
.yml definitions:
- makes sure all necessary sources are included
- updates nistkat-sha256 fields: only one entry is hashed, obtained with 'cat PQCkemKAT_<x>.rsp | head -n 10 | tail -n 8 | sha256sum'

Adds own fips202.h for avx2 version with namespace pqcrystals_fips202_avx2_##s. This is to avoid namespace collisions and portability issues if both versions are included in a library.