### PR TITLE
Adding .yml for common dependencies / namespacing

### DIFF
--- a/Common_META.yml
+++ b/Common_META.yml
@@ -1,0 +1,27 @@
+commons:
+  - name: common_ref
+    folder_name: ref
+    sources: aes256ctr.c aes256ctr.h fips202.c fips202.h
+  - name: common_aes
+    folder_name: avx2
+    sources: aes256ctr.c aes256ctr.h
+    supported_platforms:
+      - architecture: x86_64
+        operating_systems:
+          - Darwin
+          - Linux
+        required_flags:
+          - aes
+          - sse2
+          - ssse3
+  - name: common_avx2
+    folder_name: avx2
+    sources: f1600x4.S fips202.c fips202.h fips202x4.c fips202x4.h
+    supported_platforms:
+      - architecture: x86_64
+        operating_systems:
+          - Darwin
+          - Linux
+        required_flags:
+          - avx2
+          - popcnt

--- a/Dilithium2-AES_META.yml
+++ b/Dilithium2-AES_META.yml
@@ -23,14 +23,16 @@ implementations:
     signature_keypair: pqcrystals_dilithium2aes_ref_keypair
     signature_signature: pqcrystals_dilithium2aes_ref_signature
     signature_verify: pqcrystals_dilithium2aes_ref_verify
-    sources: ../LICENSE api.h config.h params.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.c ntt.h reduce.c reduce.h rounding.c rounding.h symmetric.h fips202.h symmetric-aes.c aes256ctr.h aes256ctr.c
+    sources: ../LICENSE api.h config.h params.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.c ntt.h reduce.c reduce.h rounding.c rounding.h symmetric.h fips202.h symmetric-aes.c aes256ctr.h
+    common_dep: common_ref
   - name: avx2
     version: https://github.com/pq-crystals/dilithium/commit/1e63a1e880401166f105ab44ec67464c9714a315
     compile_opts: -DDILITHIUM_MODE=2 -DDILITHIUM_USE_AES
     signature_keypair: pqcrystals_dilithium2aes_avx2_keypair
     signature_signature: pqcrystals_dilithium2aes_avx2_signature
     signature_verify: pqcrystals_dilithium2aes_avx2_verify
-    sources: ../LICENSE api.h config.h params.h align.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.S invntt.S pointwise.S ntt.h shuffle.S shuffle.inc consts.c consts.h rejsample.c rejsample.h rounding.c rounding.h symmetric.h fips202.h aes256ctr.h aes256ctr.c
+    sources: ../LICENSE api.h config.h params.h align.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.S invntt.S pointwise.S ntt.h shuffle.S shuffle.inc consts.c consts.h rejsample.c rejsample.h rounding.c rounding.h symmetric.h fips202.h aes256ctr.h
+    common_dep: common_avx2 common_aes
     supported_platforms:
       - architecture: x86_64
         operating_systems:

--- a/Dilithium2_META.yml
+++ b/Dilithium2_META.yml
@@ -23,14 +23,16 @@ implementations:
     signature_keypair: pqcrystals_dilithium2_ref_keypair
     signature_signature: pqcrystals_dilithium2_ref_signature
     signature_verify: pqcrystals_dilithium2_ref_verify
-    sources: ../LICENSE api.h config.h params.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.c ntt.h reduce.c reduce.h rounding.c rounding.h symmetric.h fips202.h fips202.c symmetric-shake.c
+    sources: ../LICENSE api.h config.h params.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.c ntt.h reduce.c reduce.h rounding.c rounding.h symmetric.h fips202.h symmetric-shake.c
+    common_dep: common_ref
   - name: avx2
     version: https://github.com/pq-crystals/dilithium/commit/1e63a1e880401166f105ab44ec67464c9714a315
     compile_opts: -DDILITHIUM_MODE=2
     signature_keypair: pqcrystals_dilithium2_avx2_keypair
     signature_signature: pqcrystals_dilithium2_avx2_signature
     signature_verify: pqcrystals_dilithium2_avx2_verify
-    sources: ../LICENSE api.h config.h params.h align.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.S invntt.S pointwise.S ntt.h shuffle.S shuffle.inc consts.c consts.h rejsample.c rejsample.h rounding.c rounding.h symmetric.h fips202.h fips202.c fips202x4.h fips202x4.c f1600x4.S symmetric-shake.c
+    sources: ../LICENSE api.h config.h params.h align.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.S invntt.S pointwise.S ntt.h shuffle.S shuffle.inc consts.c consts.h rejsample.c rejsample.h rounding.c rounding.h symmetric.h fips202.h fips202x4.h symmetric-shake.c
+    common_dep: common_avx2
     supported_platforms:
       - architecture: x86_64
         operating_systems:

--- a/Dilithium3-AES_META.yml
+++ b/Dilithium3-AES_META.yml
@@ -23,14 +23,16 @@ implementations:
     signature_keypair: pqcrystals_dilithium3aes_ref_keypair
     signature_signature: pqcrystals_dilithium3aes_ref_signature
     signature_verify: pqcrystals_dilithium3aes_ref_verify
-    sources: ../LICENSE api.h config.h params.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.c ntt.h reduce.c reduce.h rounding.c rounding.h symmetric.h fips202.h symmetric-aes.c aes256ctr.h aes256ctr.c
+    sources: ../LICENSE api.h config.h params.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.c ntt.h reduce.c reduce.h rounding.c rounding.h symmetric.h fips202.h symmetric-aes.c aes256ctr.h
+    common_dep: common_ref
   - name: avx2
     version: https://github.com/pq-crystals/dilithium/commit/1e63a1e880401166f105ab44ec67464c9714a315
     compile_opts: -DDILITHIUM_MODE=3 -DDILITHIUM_USE_AES
     signature_keypair: pqcrystals_dilithium3aes_avx2_keypair
     signature_signature: pqcrystals_dilithium3aes_avx2_signature
     signature_verify: pqcrystals_dilithium3aes_avx2_verify
-    sources: ../LICENSE api.h config.h params.h align.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.S invntt.S pointwise.S ntt.h shuffle.S shuffle.inc consts.c consts.h rejsample.c rejsample.h rounding.c rounding.h symmetric.h fips202.h aes256ctr.h aes256ctr.c
+    sources: ../LICENSE api.h config.h params.h align.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.S invntt.S pointwise.S ntt.h shuffle.S shuffle.inc consts.c consts.h rejsample.c rejsample.h rounding.c rounding.h symmetric.h fips202.h aes256ctr.h
+    common_dep: common_avx2 common_aes
     supported_platforms:
       - architecture: x86_64
         operating_systems:

--- a/Dilithium3_META.yml
+++ b/Dilithium3_META.yml
@@ -23,14 +23,16 @@ implementations:
     signature_keypair: pqcrystals_dilithium3_ref_keypair
     signature_signature: pqcrystals_dilithium3_ref_signature
     signature_verify: pqcrystals_dilithium3_ref_verify
-    sources: ../LICENSE api.h config.h params.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.c ntt.h reduce.c reduce.h rounding.c rounding.h symmetric.h fips202.h fips202.c symmetric-shake.c
+    sources: ../LICENSE api.h config.h params.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.c ntt.h reduce.c reduce.h rounding.c rounding.h symmetric.h fips202.h symmetric-shake.c
+    common_dep: common_ref
   - name: avx2
     version: https://github.com/pq-crystals/dilithium/commit/1e63a1e880401166f105ab44ec67464c9714a315
     compile_opts: -DDILITHIUM_MODE=3
     signature_keypair: pqcrystals_dilithium3_avx2_keypair
     signature_signature: pqcrystals_dilithium3_avx2_signature
     signature_verify: pqcrystals_dilithium3_avx2_verify
-    sources: ../LICENSE api.h config.h params.h align.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.S invntt.S pointwise.S ntt.h shuffle.S shuffle.inc consts.c consts.h rejsample.c rejsample.h rounding.c rounding.h symmetric.h fips202.h fips202.c fips202x4.h fips202x4.c f1600x4.S symmetric-shake.c
+    sources: ../LICENSE api.h config.h params.h align.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.S invntt.S pointwise.S ntt.h shuffle.S shuffle.inc consts.c consts.h rejsample.c rejsample.h rounding.c rounding.h symmetric.h fips202.h fips202x4.h symmetric-shake.c
+    common_dep: common_avx2
     supported_platforms:
       - architecture: x86_64
         operating_systems:

--- a/Dilithium5-AES_META.yml
+++ b/Dilithium5-AES_META.yml
@@ -23,14 +23,16 @@ implementations:
     signature_keypair: pqcrystals_dilithium5aes_ref_keypair
     signature_signature: pqcrystals_dilithium5aes_ref_signature
     signature_verify: pqcrystals_dilithium5aes_ref_verify
-    sources: ../LICENSE api.h config.h params.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.c ntt.h reduce.c reduce.h rounding.c rounding.h symmetric.h fips202.h symmetric-aes.c aes256ctr.h aes256ctr.c
+    sources: ../LICENSE api.h config.h params.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.c ntt.h reduce.c reduce.h rounding.c rounding.h symmetric.h fips202.h symmetric-aes.c aes256ctr.h
+    common_dep: common_ref
   - name: avx2
     version: https://github.com/pq-crystals/dilithium/commit/1e63a1e880401166f105ab44ec67464c9714a315
     compile_opts: -DDILITHIUM_MODE=5 -DDILITHIUM_USE_AES
     signature_keypair: pqcrystals_dilithium5aes_avx2_keypair
     signature_signature: pqcrystals_dilithium5aes_avx2_signature
     signature_verify: pqcrystals_dilithium5aes_avx2_verify
-    sources: ../LICENSE api.h config.h params.h align.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.S invntt.S pointwise.S ntt.h shuffle.S shuffle.inc consts.c consts.h rejsample.c rejsample.h rounding.c rounding.h symmetric.h fips202.h aes256ctr.h aes256ctr.c
+    sources: ../LICENSE api.h config.h params.h align.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.S invntt.S pointwise.S ntt.h shuffle.S shuffle.inc consts.c consts.h rejsample.c rejsample.h rounding.c rounding.h symmetric.h fips202.h aes256ctr.h
+    common_dep: common_avx2 common_aes
     supported_platforms:
       - architecture: x86_64
         operating_systems:

--- a/Dilithium5_META.yml
+++ b/Dilithium5_META.yml
@@ -23,14 +23,16 @@ implementations:
     signature_keypair: pqcrystals_dilithium5_ref_keypair
     signature_signature: pqcrystals_dilithium5_ref_signature
     signature_verify: pqcrystals_dilithium5_ref_verify
-    sources: ../LICENSE api.h config.h params.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.c ntt.h reduce.c reduce.h rounding.c rounding.h symmetric.h fips202.h fips202.c symmetric-shake.c
+    sources: ../LICENSE api.h config.h params.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.c ntt.h reduce.c reduce.h rounding.c rounding.h symmetric.h fips202.h symmetric-shake.c
+    common_dep: common_ref
   - name: avx2
     version: https://github.com/pq-crystals/dilithium/commit/1e63a1e880401166f105ab44ec67464c9714a315
     compile_opts: -DDILITHIUM_MODE=5
     signature_keypair: pqcrystals_dilithium5_avx2_keypair
     signature_signature: pqcrystals_dilithium5_avx2_signature
     signature_verify: pqcrystals_dilithium5_avx2_verify
-    sources: ../LICENSE api.h config.h params.h align.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.S invntt.S pointwise.S ntt.h shuffle.S shuffle.inc consts.c consts.h rejsample.c rejsample.h rounding.c rounding.h symmetric.h fips202.h fips202.c fips202x4.h fips202x4.c f1600x4.S symmetric-shake.c
+    sources: ../LICENSE api.h config.h params.h align.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.S invntt.S pointwise.S ntt.h shuffle.S shuffle.inc consts.c consts.h rejsample.c rejsample.h rounding.c rounding.h symmetric.h fips202.h fips202x4.h symmetric-shake.c
+    common_dep: common_avx2
     supported_platforms:
       - architecture: x86_64
         operating_systems:

--- a/avx2/aes256ctr.h
+++ b/avx2/aes256ctr.h
@@ -5,7 +5,7 @@
 #include <stdint.h>
 #include <immintrin.h>
 
-#define AES256CTR_NAMESPACE(s) pqcrystals_aes256ctr_avx2_##s
+#define AES256CTR_NAMESPACE(s) pqcrystals_dilithium_aes256ctr_avx2_##s
 
 #define AES256CTR_BLOCKBYTES 64
 

--- a/avx2/fips202.h
+++ b/avx2/fips202.h
@@ -9,7 +9,7 @@
 #define SHA3_256_RATE 136
 #define SHA3_512_RATE 72
 
-#define FIPS202_NAMESPACE(s) pqcrystals_fips202_avx2_##s
+#define FIPS202_NAMESPACE(s) pqcrystals_dilithium_fips202_avx2_##s
 
 typedef struct {
   uint64_t s[25];

--- a/avx2/fips202x4.h
+++ b/avx2/fips202x4.h
@@ -1,7 +1,7 @@
 #ifndef FIPS202X4_H
 #define FIPS202X4_H
 
-#define FIPS202X4_NAMESPACE(s) pqcrystals_fips202x4_avx2_##s
+#define FIPS202X4_NAMESPACE(s) pqcrystals_dilithium_fips202x4_avx2_##s
 
 #ifdef __ASSEMBLER__
 /* The C ABI on MacOS exports all symbols with a leading

--- a/ref/aes256ctr.h
+++ b/ref/aes256ctr.h
@@ -6,7 +6,7 @@
 
 #define AES256CTR_BLOCKBYTES 64
 
-#define AES256CTR_NAMESPACE(s) pqcrystals_aes256ctr_ref_##s
+#define AES256CTR_NAMESPACE(s) pqcrystals_dilithium_aes256ctr_ref_##s
 
 typedef struct {
   uint64_t sk_exp[120];

--- a/ref/fips202.h
+++ b/ref/fips202.h
@@ -9,7 +9,7 @@
 #define SHA3_256_RATE 136
 #define SHA3_512_RATE 72
 
-#define FIPS202_NAMESPACE(s) pqcrystals_fips202_ref_##s
+#define FIPS202_NAMESPACE(s) pqcrystals_dilithium_fips202_ref_##s
 
 typedef struct {
   uint64_t s[25];


### PR DESCRIPTION
- Added Commons_META.yml to define common dependencies for implementations and parameter sets.

- Made namespaces for fips202, fips202x4, aes256ctr etc more distinctive to avoid collisions when both kyber and dilithium are linked at the same time.