### PR TITLE
Typing fixes for compiling on GCC 11.1

### DIFF
--- a/avx2/aes256ctr.c
+++ b/avx2/aes256ctr.c
@@ -119,27 +119,3 @@ void aes256ctr_squeezeblocks(uint8_t *out,
     out += 64;
   }
 }
-
-void aes256ctr_prf(uint8_t *out,
-                   size_t outlen,
-                   const uint8_t seed[32],
-                   uint64_t nonce)
-{
-  unsigned int i;
-  uint8_t buf[64];
-  aes256ctr_ctx state;
-
-  aes256ctr_init(&state, seed, nonce);
-
-  while(outlen >= 64) {
-    aesni_encrypt4(out, &state.n, state.rkeys);
-    outlen -= 64;
-    out += 64;
-  }
-
-  if(outlen) {
-    aesni_encrypt4(buf, &state.n, state.rkeys);
-    for(i=0;i<outlen;i++)
-      out[i] = buf[i];
-  }
-}

--- a/avx2/aes256ctr.h
+++ b/avx2/aes256ctr.h
@@ -24,10 +24,4 @@ void aes256ctr_squeezeblocks(uint8_t *out,
                              size_t nblocks,
                              aes256ctr_ctx *state);
 
-#define aes256ctr_prf AES256CTR_NAMESPACE(prf)
-void aes256ctr_prf(uint8_t *out,
-                   size_t outlen,
-                   const uint8_t key[32],
-                   uint64_t nonce);
-
 #endif

--- a/avx2/poly.c
+++ b/avx2/poly.c
@@ -1011,7 +1011,7 @@ void polyz_pack(uint8_t r[POLYZ_PACKEDBYTES], const poly * restrict a) {
 *              - const uint8_t *a: byte array with bit-packed polynomial
 **************************************************/
 #if GAMMA1 == (1 << 17)
-void polyz_unpack(poly * restrict r, const uint8_t a[POLYZ_PACKEDBYTES+14]) {
+void polyz_unpack(poly * restrict r, const uint8_t *a) {
   unsigned int i;
   __m256i f;
   const __m256i shufbidx = _mm256_set_epi8(-1, 9, 8, 7,-1, 7, 6, 5,-1, 5, 4, 3,-1, 3, 2, 1,
@@ -1035,7 +1035,7 @@ void polyz_unpack(poly * restrict r, const uint8_t a[POLYZ_PACKEDBYTES+14]) {
 }
 
 #elif GAMMA1 == (1 << 19)
-void polyz_unpack(poly * restrict r, const uint8_t a[POLYZ_PACKEDBYTES+12]) {
+void polyz_unpack(poly * restrict r, const uint8_t *a) {
   unsigned int i;
   __m256i f;
   const __m256i shufbidx = _mm256_set_epi8(-1,11,10, 9,-1, 9, 8, 7,-1, 6, 5, 4,-1, 4, 3, 2,
@@ -1070,7 +1070,7 @@ void polyz_unpack(poly * restrict r, const uint8_t a[POLYZ_PACKEDBYTES+12]) {
 *              - const poly *a: pointer to input polynomial
 **************************************************/
 #if GAMMA2 == (Q-1)/88
-void polyw1_pack(uint8_t r[POLYW1_PACKEDBYTES+8], const poly * restrict a) {
+void polyw1_pack(uint8_t *r, const poly * restrict a) {
   unsigned int i;
   __m256i f0,f1,f2,f3;
   const __m256i shift1 = _mm256_set1_epi16((64 << 8) + 1);
@@ -1101,7 +1101,7 @@ void polyw1_pack(uint8_t r[POLYW1_PACKEDBYTES+8], const poly * restrict a) {
 }
 
 #elif GAMMA2 == (Q-1)/32
-void polyw1_pack(uint8_t r[POLYW1_PACKEDBYTES], const poly * restrict a) {
+void polyw1_pack(uint8_t *r, const poly * restrict a) {
   unsigned int i;
   __m256i f0, f1, f2, f3, f4, f5, f6, f7;
   const __m256i shift = _mm256_set1_epi16((16 << 8) + 1);

--- a/avx2/poly.h
+++ b/avx2/poly.h
@@ -106,9 +106,9 @@ void polyt0_unpack(poly *r, const uint8_t a[POLYT0_PACKEDBYTES]);
 #define polyz_pack DILITHIUM_NAMESPACE(polyz_pack)
 void polyz_pack(uint8_t r[POLYZ_PACKEDBYTES], const poly *a);
 #define polyz_unpack DILITHIUM_NAMESPACE(polyz_unpack)
-void polyz_unpack(poly *r, const uint8_t a[POLYZ_PACKEDBYTES+14]);
+void polyz_unpack(poly *r, const uint8_t *a);
 
 #define polyw1_pack DILITHIUM_NAMESPACE(polyw1_pack)
-void polyw1_pack(uint8_t r[POLYW1_PACKEDBYTES+8], const poly *a);
+void polyw1_pack(uint8_t *r, const poly *a);
 
 #endif

--- a/avx2/rejsample.h
+++ b/avx2/rejsample.h
@@ -22,7 +22,7 @@ extern const uint8_t idxlut[256][8];
 unsigned int rej_uniform_avx(int32_t *r, const uint8_t buf[REJ_UNIFORM_BUFLEN+8]);
 
 #define rej_eta_avx DILITHIUM_NAMESPACE(rej_eta_avx)
-unsigned int rej_eta_avx(int32_t *r, const uint8_t buf[REJ_UNIFORM_BUFLEN]);
+unsigned int rej_eta_avx(int32_t *r, const uint8_t buf[REJ_UNIFORM_ETA_BUFLEN]);
 
 #endif
 

--- a/ref/aes256ctr.c
+++ b/ref/aes256ctr.c
@@ -483,7 +483,7 @@ static void inc4_be(uint32_t *x)
   *x = br_swap32(*x);
 }
 
-static void aes_ctr4x(uint8_t out[64], uint32_t ivw[16], uint64_t sk_exp[64])
+static void aes_ctr4x(uint8_t out[64], uint32_t ivw[16], uint64_t sk_exp[120])
 {
   uint32_t w[16];
   uint64_t q[8];
@@ -527,42 +527,7 @@ static void br_aes_ct64_ctr_init(uint64_t sk_exp[120], const uint8_t *key)
 	br_aes_ct64_skey_expand(sk_exp, skey);
 }
 
-static void br_aes_ct64_ctr_run(uint64_t sk_exp[120], const uint8_t *iv, uint32_t cc, uint8_t *data, size_t len)
-{
-	uint32_t ivw[16];
-	size_t i;
-
-	br_range_dec32le(ivw, 3, iv);
-	memcpy(ivw +  4, ivw, 3 * sizeof(uint32_t));
-	memcpy(ivw +  8, ivw, 3 * sizeof(uint32_t));
-	memcpy(ivw + 12, ivw, 3 * sizeof(uint32_t));
-	ivw[ 3] = br_swap32(cc);
-	ivw[ 7] = br_swap32(cc + 1);
-	ivw[11] = br_swap32(cc + 2);
-	ivw[15] = br_swap32(cc + 3);
-
-	while (len > 64) {
-		aes_ctr4x(data, ivw, sk_exp);
-		data += 64;
-		len -= 64;
-	}
-	if(len > 0) {
-		uint8_t tmp[64];
-		aes_ctr4x(tmp, ivw, sk_exp);
-		for(i=0;i<len;i++)
-			data[i] = tmp[i];
-	}
-}
-
-void aes256ctr_prf(uint8_t *out, size_t outlen, const uint8_t *key, const uint8_t *nonce)
-{
-  uint64_t sk_exp[120];
-
-  br_aes_ct64_ctr_init(sk_exp, key);
-  br_aes_ct64_ctr_run(sk_exp, nonce, 0, out, outlen);
-}
-
-void aes256ctr_init(aes256ctr_ctx *s, const uint8_t *key, const uint8_t *nonce)
+void aes256ctr_init(aes256ctr_ctx *s, const uint8_t key[32], const uint8_t nonce[12])
 {
   br_aes_ct64_ctr_init(s->sk_exp, key);
 

--- a/ref/aes256ctr.h
+++ b/ref/aes256ctr.h
@@ -13,12 +13,6 @@ typedef struct {
   uint32_t ivw[16];
 } aes256ctr_ctx;
 
-#define aes256ctr_prf AES256CTR_NAMESPACE(prf)
-void aes256ctr_prf(uint8_t *out,
-                   size_t outlen,
-                   const uint8_t key[32],
-                   const uint8_t nonce[12]);
-
 #define aes256ctr_init AES256CTR_NAMESPACE(init)
 void aes256ctr_init(aes256ctr_ctx *state,
                     const uint8_t key[32],


### PR DESCRIPTION
This PR enables compiling with newer gcc versions. Building with GCC 11.1 currently fails because of stricter type checking.

- Fixes a few typing inconsistencies between source files and headers.
- Removes some unused aes code.

Fixes #49.
Also necessary to address https://github.com/open-quantum-safe/liboqs/issues/1035.