### PR TITLE
Fixed documentation of poly_uniform

### DIFF
--- a/ref/poly.c
+++ b/ref/poly.c
@@ -335,7 +335,7 @@ static unsigned int rej_uniform(int32_t *a,
 *
 * Description: Sample polynomial with uniformly random coefficients
 *              in [0,Q-1] by performing rejection sampling on the
-*              output stream of SHAKE256(seed|nonce) or AES256CTR(seed,nonce).
+*              output stream of SHAKE128(seed|nonce) or AES256CTR(seed,nonce).
 *
 * Arguments:   - poly *a: pointer to output polynomial
 *              - const uint8_t seed[]: byte array with seed of length SEEDBYTES


### PR DESCRIPTION
Fixed documentation of poly_uniform (used during ExpandA) to SHAKE128 from SHAKE256.