### PR TITLE
fix documentation on the description of verify

### DIFF
--- a/ref/sign.c
+++ b/ref/sign.c
@@ -213,7 +213,7 @@ int crypto_sign(uint8_t *sm,
 *
 * Description: Verifies signature.
 *
-* Arguments:   - uint8_t *m: pointer to input signature
+* Arguments:   - const uint8_t *sig: pointer to input signature
 *              - size_t siglen: length of signature
 *              - const uint8_t *m: pointer to message
 *              - size_t mlen: length of message


### PR DESCRIPTION
Small edit to correctly describe the arguments of `crypto_sign_verify`.