### PR TITLE
Fix: Apply mask to second coefficient

### DIFF
--- a/ref/poly.c
+++ b/ref/poly.c
@@ -865,7 +865,7 @@ void polyz_unpack(poly *r, const uint8_t *a) {
     r->coeffs[2*i+1]  = a[5*i+2] >> 4;
     r->coeffs[2*i+1] |= (uint32_t)a[5*i+3] << 4;
     r->coeffs[2*i+1] |= (uint32_t)a[5*i+4] << 12;
-    r->coeffs[2*i+0] &= 0xFFFFF;
+    r->coeffs[2*i+1] &= 0xFFFFF;
 
     r->coeffs[2*i+0] = GAMMA1 - r->coeffs[2*i+0];
     r->coeffs[2*i+1] = GAMMA1 - r->coeffs[2*i+1];


### PR DESCRIPTION
If I read this function correctly, the masking of the second coefficient has been a victim of copy and paste and therefore the mask is applied to the first coefficient twice.