### PR TITLE
A few fixes for the standard-version

### DIFF
--- a/Dilithium2_META.yml
+++ b/Dilithium2_META.yml
@@ -2,10 +2,10 @@ name: Dilithium2
 type: signature
 claimed-nist-level: 2
 length-public-key: 1312
-length-secret-key: 2528
+length-secret-key: 2560
 length-signature: 2420
-nistkat-sha256: 26ae9c1224171e957dbe38672942d31edb7dffbe700825e0cb52128cdb45280a
-testvectors-sha256: b56155479f5643a3cb3d73260ba2b1fd7e772a49b6f4cebcf742cd860fbf6879
+nistkat-sha256: e6f3ec4dc0b02dd3bcbbc6b105190e1890ca0bb3f802e2b571f0d70f3993a2e1
+testvectors-sha256: aff4dbcb0c5ad52c840036907661efd2cafd6c1cba95ed052184f45adf30f365
 principal-submitters:
   - Vadim Lyubashevsky
 auxiliary-submitters:
@@ -18,17 +18,17 @@ auxiliary-submitters:
   - Damien Stehlé
 implementations:
   - name: ref
-    version: https://github.com/pq-crystals/dilithium/commit/d9c885d3f2e11c05529eeeb7d70d808c972b8409
+    version: https://github.com/pq-crystals/dilithium/tree/standard
     folder_name: ref
-    compile_opts: -DDILITHIUM_MODE=2 -DDILITHIUM_RANDOMIZED_SIGNING
+    compile_opts: -DDILITHIUM_MODE=2
     signature_keypair: pqcrystals_dilithium2_ref_keypair
     signature_signature: pqcrystals_dilithium2_ref_signature
     signature_verify: pqcrystals_dilithium2_ref_verify
     sources: ../LICENSE api.h config.h params.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.c ntt.h reduce.c reduce.h rounding.c rounding.h symmetric.h fips202.h symmetric-shake.c
     common_dep: common_ref
   - name: avx2
-    version: https://github.com/pq-crystals/dilithium/commit/d9c885d3f2e11c05529eeeb7d70d808c972b8409
-    compile_opts: -DDILITHIUM_MODE=2 -DDILITHIUM_RANDOMIZED_SIGNING
+    version: https://github.com/pq-crystals/dilithium/tree/standard
+    compile_opts: -DDILITHIUM_MODE=2
     signature_keypair: pqcrystals_dilithium2_avx2_keypair
     signature_signature: pqcrystals_dilithium2_avx2_signature
     signature_verify: pqcrystals_dilithium2_avx2_verify

--- a/Dilithium3_META.yml
+++ b/Dilithium3_META.yml
@@ -2,10 +2,10 @@ name: Dilithium3
 type: signature
 claimed-nist-level: 3
 length-public-key: 1952
-length-secret-key: 4000
-length-signature: 3293
-nistkat-sha256: eea584803c3d6991a4acbf9f117147bbdd246faf822cfb1a17effe20b2052ba9
-testvectors-sha256: a237032c7840a0d2f922951f806c2199f8f86b8a8947f6f6f1b856c925222958
+length-secret-key: 4032
+length-signature: 3309
+nistkat-sha256: 7225c4531086d88c9b7fa18101b0f78dda2d38df88812c65ddc1ae94fe3c01a7
+testvectors-sha256: e0a98c0a29137dcbeb12104ccaa6a0555a9bdb4dcfbc2b0fc9a959dd8b6c8699
 principal-submitters:
   - Vadim Lyubashevsky
 auxiliary-submitters:
@@ -18,17 +18,17 @@ auxiliary-submitters:
   - Damien Stehlé
 implementations:
   - name: ref
-    version: https://github.com/pq-crystals/dilithium/commit/d9c885d3f2e11c05529eeeb7d70d808c972b8409
+    version: https://github.com/pq-crystals/dilithium/tree/standard
     folder_name: ref
-    compile_opts: -DDILITHIUM_MODE=3 -DDILITHIUM_RANDOMIZED_SIGNING
+    compile_opts: -DDILITHIUM_MODE=3
     signature_keypair: pqcrystals_dilithium3_ref_keypair
     signature_signature: pqcrystals_dilithium3_ref_signature
     signature_verify: pqcrystals_dilithium3_ref_verify
     sources: ../LICENSE api.h config.h params.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.c ntt.h reduce.c reduce.h rounding.c rounding.h symmetric.h fips202.h symmetric-shake.c
     common_dep: common_ref
   - name: avx2
-    version: https://github.com/pq-crystals/dilithium/commit/d9c885d3f2e11c05529eeeb7d70d808c972b8409
-    compile_opts: -DDILITHIUM_MODE=3 -DDILITHIUM_RANDOMIZED_SIGNING
+    version: https://github.com/pq-crystals/dilithium/tree/standard
+    compile_opts: -DDILITHIUM_MODE=3
     signature_keypair: pqcrystals_dilithium3_avx2_keypair
     signature_signature: pqcrystals_dilithium3_avx2_signature
     signature_verify: pqcrystals_dilithium3_avx2_verify

--- a/Dilithium5_META.yml
+++ b/Dilithium5_META.yml
@@ -2,10 +2,10 @@ name: Dilithium5
 type: signature
 claimed-nist-level: 5
 length-public-key: 2592
-length-secret-key: 4864
-length-signature: 4595
-nistkat-sha256: 3f6e58603a38be57cf08d79b01fcfd0ccc1129a09e14a6122c6fe22c906ddc3b
-testvectors-sha256: ddeb95f4a743562010bce527ea7c99fed4ce1234bafd5ed6f44eea0f065ba49c
+length-secret-key: 4896
+length-signature: 4627
+nistkat-sha256: f5cb5ed44a261a4118f9cfd5d55b4210939cb5b8531968a10c37060551a8927f
+testvectors-sha256: 9a1985c10b13efefee50067edf3432ed8ab48a62965743feb45a317485980883
 principal-submitters:
   - Vadim Lyubashevsky
 auxiliary-submitters:
@@ -18,17 +18,17 @@ auxiliary-submitters:
   - Damien Stehlé
 implementations:
   - name: ref
-    version: https://github.com/pq-crystals/dilithium/commit/d9c885d3f2e11c05529eeeb7d70d808c972b8409
+    version: https://github.com/pq-crystals/dilithium/tree/standard
     folder_name: ref
-    compile_opts: -DDILITHIUM_MODE=5 -DDILITHIUM_RANDOMIZED_SIGNING
+    compile_opts: -DDILITHIUM_MODE=5
     signature_keypair: pqcrystals_dilithium5_ref_keypair
     signature_signature: pqcrystals_dilithium5_ref_signature
     signature_verify: pqcrystals_dilithium5_ref_verify
     sources: ../LICENSE api.h config.h params.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.c ntt.h reduce.c reduce.h rounding.c rounding.h symmetric.h fips202.h symmetric-shake.c
     common_dep: common_ref
   - name: avx2
-    version: https://github.com/pq-crystals/dilithium/commit/d9c885d3f2e11c05529eeeb7d70d808c972b8409
-    compile_opts: -DDILITHIUM_MODE=5 -DDILITHIUM_RANDOMIZED_SIGNING
+    version: https://github.com/pq-crystals/dilithium/tree/standard
+    compile_opts: -DDILITHIUM_MODE=5
     signature_keypair: pqcrystals_dilithium5_avx2_keypair
     signature_signature: pqcrystals_dilithium5_avx2_signature
     signature_verify: pqcrystals_dilithium5_avx2_verify

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ brew install openssl
 ```
 Then, run
 ```sh
-export CFLAGS="-I/usr/local/opt/openssl@1.1/include"
-export NISTFLAGS="-I/usr/local/opt/openssl@1.1/include"
-export LDFLAGS="-L/usr/local/opt/openssl@1.1/lib"
+export CFLAGS="-I/opt/homebrew/opt/openssl@1.1/include"
+export NISTFLAGS="-I/opt/homebrew/opt/openssl@1.1/include"
+export LDFLAGS="-L/opt/homebrew/opt/openssl@1.1/lib"
 ```
 before compilation to add the OpenSSL header and library locations to the respective search paths.
 
@@ -60,11 +60,11 @@ Our Dilithium implementations are contained in the [SUPERCOP](https://bench.cr.y
 
 ## Randomized signing
 
-By default our code implements Dilithium's deterministic signing mode. To change this to the randomized signing mode, define the `DILITHIUM_RANDOMIZED_SIGNING` preprocessor macro at compilation by either uncommenting the line
+By default our code implements Dilithium's randomized signing mode. To change this to the deterministic signing mode, undefine the `DILITHIUM_RANDOMIZED_SIGNING` preprocessor macro at compilation by commenting the line
 ```sh
-//#define DILITHIUM_RANDOMIZED_SIGNING
+#define DILITHIUM_RANDOMIZED_SIGNING
 ```
-in config.h, or adding `-DDILITHIUM_RANDOMIZED_SIGNING` to the compiler flags in the environment variable `CFLAGS`.
+in config.h.
 
 ## Shared libraries
 

--- a/avx2/api.h
+++ b/avx2/api.h
@@ -5,7 +5,7 @@
 #include <stdint.h>
 
 #define pqcrystals_dilithium2_PUBLICKEYBYTES 1312
-#define pqcrystals_dilithium2_SECRETKEYBYTES 2528
+#define pqcrystals_dilithium2_SECRETKEYBYTES 2560
 #define pqcrystals_dilithium2_BYTES 2420
 
 #define pqcrystals_dilithium2_avx2_PUBLICKEYBYTES pqcrystals_dilithium2_PUBLICKEYBYTES
@@ -32,8 +32,8 @@ int pqcrystals_dilithium2_avx2_open(uint8_t *m, size_t *mlen,
 
 
 #define pqcrystals_dilithium3_PUBLICKEYBYTES 1952
-#define pqcrystals_dilithium3_SECRETKEYBYTES 4000
-#define pqcrystals_dilithium3_BYTES 3293
+#define pqcrystals_dilithium3_SECRETKEYBYTES 4032
+#define pqcrystals_dilithium3_BYTES 3309
 
 #define pqcrystals_dilithium3_avx2_PUBLICKEYBYTES pqcrystals_dilithium3_PUBLICKEYBYTES
 #define pqcrystals_dilithium3_avx2_SECRETKEYBYTES pqcrystals_dilithium3_SECRETKEYBYTES
@@ -59,8 +59,8 @@ int pqcrystals_dilithium3_avx2_open(uint8_t *m, size_t *mlen,
 
 
 #define pqcrystals_dilithium5_PUBLICKEYBYTES 2592
-#define pqcrystals_dilithium5_SECRETKEYBYTES 4864
-#define pqcrystals_dilithium5_BYTES 4595
+#define pqcrystals_dilithium5_SECRETKEYBYTES 4896
+#define pqcrystals_dilithium5_BYTES 4627
 
 #define pqcrystals_dilithium5_avx2_PUBLICKEYBYTES pqcrystals_dilithium5_PUBLICKEYBYTES
 #define pqcrystals_dilithium5_avx2_SECRETKEYBYTES pqcrystals_dilithium5_SECRETKEYBYTES

--- a/avx2/config.h
+++ b/avx2/config.h
@@ -2,7 +2,7 @@
 #define CONFIG_H
 
 //#define DILITHIUM_MODE 2
-//#define DILITHIUM_RANDOMIZED_SIGNING
+#define DILITHIUM_RANDOMIZED_SIGNING
 //#define USE_RDPMC
 //#define DBENCH
 

--- a/ref/api.h
+++ b/ref/api.h
@@ -5,7 +5,7 @@
 #include <stdint.h>
 
 #define pqcrystals_dilithium2_PUBLICKEYBYTES 1312
-#define pqcrystals_dilithium2_SECRETKEYBYTES 2528
+#define pqcrystals_dilithium2_SECRETKEYBYTES 2560
 #define pqcrystals_dilithium2_BYTES 2420
 
 #define pqcrystals_dilithium2_ref_PUBLICKEYBYTES pqcrystals_dilithium2_PUBLICKEYBYTES
@@ -32,8 +32,8 @@ int pqcrystals_dilithium2_ref_open(uint8_t *m, size_t *mlen,
 
 
 #define pqcrystals_dilithium3_PUBLICKEYBYTES 1952
-#define pqcrystals_dilithium3_SECRETKEYBYTES 4000
-#define pqcrystals_dilithium3_BYTES 3293
+#define pqcrystals_dilithium3_SECRETKEYBYTES 4032
+#define pqcrystals_dilithium3_BYTES 3309
 
 #define pqcrystals_dilithium3_ref_PUBLICKEYBYTES pqcrystals_dilithium3_PUBLICKEYBYTES
 #define pqcrystals_dilithium3_ref_SECRETKEYBYTES pqcrystals_dilithium3_SECRETKEYBYTES
@@ -59,8 +59,8 @@ int pqcrystals_dilithium3_ref_open(uint8_t *m, size_t *mlen,
 
 
 #define pqcrystals_dilithium5_PUBLICKEYBYTES 2592
-#define pqcrystals_dilithium5_SECRETKEYBYTES 4864
-#define pqcrystals_dilithium5_BYTES 4595
+#define pqcrystals_dilithium5_SECRETKEYBYTES 4896
+#define pqcrystals_dilithium5_BYTES 4627
 
 #define pqcrystals_dilithium5_ref_PUBLICKEYBYTES pqcrystals_dilithium5_PUBLICKEYBYTES
 #define pqcrystals_dilithium5_ref_SECRETKEYBYTES pqcrystals_dilithium5_SECRETKEYBYTES

--- a/ref/config.h
+++ b/ref/config.h
@@ -2,7 +2,7 @@
 #define CONFIG_H
 
 //#define DILITHIUM_MODE 2
-//#define DILITHIUM_RANDOMIZED_SIGNING
+#define DILITHIUM_RANDOMIZED_SIGNING
 //#define USE_RDPMC
 //#define DBENCH
 

--- a/ref/packing.h
+++ b/ref/packing.h
@@ -18,7 +18,7 @@ void pack_sk(uint8_t sk[CRYPTO_SECRETKEYBYTES],
              const polyveck *s2);
 
 #define pack_sig DILITHIUM_NAMESPACE(pack_sig)
-void pack_sig(uint8_t sig[CRYPTO_BYTES], const uint8_t c[SEEDBYTES], const polyvecl *z, const polyveck *h);
+void pack_sig(uint8_t sig[CRYPTO_BYTES], const uint8_t c[CTILDEBYTES], const polyvecl *z, const polyveck *h);
 
 #define unpack_pk DILITHIUM_NAMESPACE(unpack_pk)
 void unpack_pk(uint8_t rho[SEEDBYTES], polyveck *t1, const uint8_t pk[CRYPTO_PUBLICKEYBYTES]);
@@ -33,6 +33,6 @@ void unpack_sk(uint8_t rho[SEEDBYTES],
                const uint8_t sk[CRYPTO_SECRETKEYBYTES]);
 
 #define unpack_sig DILITHIUM_NAMESPACE(unpack_sig)
-int unpack_sig(uint8_t c[SEEDBYTES], polyvecl *z, polyveck *h, const uint8_t sig[CRYPTO_BYTES]);
+int unpack_sig(uint8_t c[CTILDEBYTES], polyvecl *z, polyveck *h, const uint8_t sig[CRYPTO_BYTES]);
 
 #endif


### PR DESCRIPTION
Adds a few fixes to the standard branch (assuming this branch intends to sync with the FIPS204 draft).

- Fixes macros for signature and private key sizes in api.h (the macros in params.h appear to be already up-to-date):
 -> private keys increase by 32 bytes because of increased `tr` (256 bit to 512 bit)
 -> signature sizes of the -65 and -87 versions increased as noted in https://groups.google.com/a/list.nist.gov/g/pqc-forum/c/EKoI0u_PuOw/m/xQVnr5D0AQAJ?pli=1
- packing.h headers were inconsistent with packing.c, causing warnings/errors with newer gcc-versions.
- makes randomized signing (with a random rnd) the default option as described in the FIPS204 draft.
- updates sizes and test vector/kat hashes in the .yml files
- updates macOS build instructions (homebrew locations changed in newer versions)