### PR TITLE
Fix api constants

### DIFF
--- a/avx2/Makefile
+++ b/avx2/Makefile
@@ -8,7 +8,7 @@ SOURCES = sign.c packing.c polyvec.c poly.c ntt.S invntt.S pointwise.S \
   shuffle.S consts.c rejsample.c rounding.c
 HEADERS = align.h config.h params.h api.h sign.h packing.h polyvec.h poly.h ntt.h \
   consts.h shuffle.inc rejsample.h rounding.h symmetric.h randombytes.h
-KECCAK_SOURCES = $(SOURCES) fips202.c fips202x4.c f1600x4.S symmetric-shake.c
+KECCAK_SOURCES = $(SOURCES) fips202.c fips202x4.c f1600x4.S symmetric-shake.c test/assert-params.c
 KECCAK_HEADERS = $(HEADERS) fips202.h fips202x4.h
 
 .PHONY: all shared clean
@@ -41,14 +41,17 @@ libpqcrystals_fips202x4_avx2.so: fips202x4.c fips202x4.h f1600x4.S
 	$(CC) -shared -fPIC $(CFLAGS) -o $@ $< f1600x4.S
 
 libpqcrystals_dilithium2_avx2.so: $(SOURCES) $(HEADERS) symmetric-shake.c
+	$(CC) --syntax-only test/assert-params.c -DDILITHIUM_MODE=2
 	$(CC) -shared -fPIC $(CFLAGS) -DDILITHIUM_MODE=2 \
 	  -o $@ $(SOURCES) symmetric-shake.c
 
 libpqcrystals_dilithium3_avx2.so: $(SOURCES) $(HEADERS) symmetric-shake.c
+	$(CC) --syntax-only test/assert-params.c -DDILITHIUM_MODE=3
 	$(CC) -shared -fPIC $(CFLAGS) -DDILITHIUM_MODE=3 \
 	  -o $@ $(SOURCES) symmetric-shake.c
 
 libpqcrystals_dilithium5_avx2.so: $(SOURCES) $(HEADERS) symmetric-shake.c
+	$(CC) --syntax-only test/assert-params.c -DDILITHIUM_MODE=5
 	$(CC) -shared -fPIC $(CFLAGS) -DDILITHIUM_MODE=5 \
 	  -o $@ $(SOURCES) symmetric-shake.c
 

--- a/avx2/api.h
+++ b/avx2/api.h
@@ -5,7 +5,7 @@
 #include <stdint.h>
 
 #define pqcrystals_dilithium2_PUBLICKEYBYTES 1312
-#define pqcrystals_dilithium2_SECRETKEYBYTES 2528
+#define pqcrystals_dilithium2_SECRETKEYBYTES 2560
 #define pqcrystals_dilithium2_BYTES 2420
 
 #define pqcrystals_dilithium2_avx2_PUBLICKEYBYTES pqcrystals_dilithium2_PUBLICKEYBYTES
@@ -32,8 +32,8 @@ int pqcrystals_dilithium2_avx2_open(uint8_t *m, size_t *mlen,
 
 
 #define pqcrystals_dilithium3_PUBLICKEYBYTES 1952
-#define pqcrystals_dilithium3_SECRETKEYBYTES 4000
-#define pqcrystals_dilithium3_BYTES 3293
+#define pqcrystals_dilithium3_SECRETKEYBYTES 4032
+#define pqcrystals_dilithium3_BYTES 3309
 
 #define pqcrystals_dilithium3_avx2_PUBLICKEYBYTES pqcrystals_dilithium3_PUBLICKEYBYTES
 #define pqcrystals_dilithium3_avx2_SECRETKEYBYTES pqcrystals_dilithium3_SECRETKEYBYTES
@@ -59,8 +59,8 @@ int pqcrystals_dilithium3_avx2_open(uint8_t *m, size_t *mlen,
 
 
 #define pqcrystals_dilithium5_PUBLICKEYBYTES 2592
-#define pqcrystals_dilithium5_SECRETKEYBYTES 4864
-#define pqcrystals_dilithium5_BYTES 4595
+#define pqcrystals_dilithium5_SECRETKEYBYTES 4896
+#define pqcrystals_dilithium5_BYTES 4627
 
 #define pqcrystals_dilithium5_avx2_PUBLICKEYBYTES pqcrystals_dilithium5_PUBLICKEYBYTES
 #define pqcrystals_dilithium5_avx2_SECRETKEYBYTES pqcrystals_dilithium5_SECRETKEYBYTES

--- a/avx2/test/assert-params.c
+++ b/avx2/test/assert-params.c
@@ -1,0 +1,32 @@
+/*
+This code ensures that the defines in api.h are aligned with the ones in param.h
+It doesnt generate any executable code.
+*/
+
+#include "../params.h"
+#include "../api.h"
+
+#define STR_HELPER(x) #x
+#define STR(x) STR_HELPER(x)
+
+#define pqcrystals_dilithium(mode, val) pqcrystals_dilithium_(mode, val)
+#define pqcrystals_dilithium_(mode, val) pqcrystals_dilithium##mode##_##val
+
+#define pqcrystals_dilithium_PUBLICKEYBYTES pqcrystals_dilithium(DILITHIUM_MODE, PUBLICKEYBYTES)
+#define pqcrystals_dilithium_SECRETKEYBYTES pqcrystals_dilithium(DILITHIUM_MODE, SECRETKEYBYTES)
+#define pqcrystals_dilithium_BYTES pqcrystals_dilithium(DILITHIUM_MODE, BYTES)
+
+#if pqcrystals_dilithium_PUBLICKEYBYTES != CRYPTO_PUBLICKEYBYTES
+#pragma message "building dilithium" STR(DILITHIUM_MODE)
+#error pqcrystals_dilithium_PUBLICKEYBYTES != CRYPTO_PUBLICKEYBYTES
+#endif
+
+#if pqcrystals_dilithium_SECRETKEYBYTES != CRYPTO_SECRETKEYBYTES
+#pragma message "building dilithium" STR(DILITHIUM_MODE)
+#error pqcrystals_dilithium_SECRETKEYBYTES != CRYPTO_SECRETKEYBYTES
+#endif
+
+#if pqcrystals_dilithium_BYTES != CRYPTO_BYTES
+#pragma message "building dilithium" STR(DILITHIUM_MODE)
+#error pqcrystals_dilithium_BYTES != CRYPTO_BYTES
+#endif

--- a/ref/Makefile
+++ b/ref/Makefile
@@ -5,7 +5,7 @@ NISTFLAGS += -Wno-unused-result -O3 -fomit-frame-pointer
 SOURCES = sign.c packing.c polyvec.c poly.c ntt.c reduce.c rounding.c
 HEADERS = config.h params.h api.h sign.h packing.h polyvec.h poly.h ntt.h \
   reduce.h rounding.h symmetric.h randombytes.h
-KECCAK_SOURCES = $(SOURCES) fips202.c symmetric-shake.c
+KECCAK_SOURCES = $(SOURCES) fips202.c symmetric-shake.c test/assert-params.c
 KECCAK_HEADERS = $(HEADERS) fips202.h
 
 .PHONY: all speed shared clean
@@ -37,14 +37,17 @@ libpqcrystals_fips202_ref.so: fips202.c fips202.h
 	$(CC) -shared -fPIC $(CFLAGS) -o $@ $<
 
 libpqcrystals_dilithium2_ref.so: $(SOURCES) $(HEADERS) symmetric-shake.c
+	$(CC) --syntax-only test/assert-params.c -DDILITHIUM_MODE=2
 	$(CC) -shared -fPIC $(CFLAGS) -DDILITHIUM_MODE=2 \
 	  -o $@ $(SOURCES) symmetric-shake.c
 
 libpqcrystals_dilithium3_ref.so: $(SOURCES) $(HEADERS) symmetric-shake.c
+	$(CC) --syntax-only test/assert-params.c -DDILITHIUM_MODE=3
 	$(CC) -shared -fPIC $(CFLAGS) -DDILITHIUM_MODE=3 \
 	  -o $@ $(SOURCES) symmetric-shake.c
 
 libpqcrystals_dilithium5_ref.so: $(SOURCES) $(HEADERS) symmetric-shake.c
+	$(CC) --syntax-only test/assert-params.c -DDILITHIUM_MODE=5
 	$(CC) -shared -fPIC $(CFLAGS) -DDILITHIUM_MODE=5 \
 	  -o $@ $(SOURCES) symmetric-shake.c
 

--- a/ref/api.h
+++ b/ref/api.h
@@ -33,7 +33,7 @@ int pqcrystals_dilithium2_ref_open(uint8_t *m, size_t *mlen,
 
 #define pqcrystals_dilithium3_PUBLICKEYBYTES 1952
 #define pqcrystals_dilithium3_SECRETKEYBYTES 4032
-#define pqcrystals_dilithium3_BYTES 3293
+#define pqcrystals_dilithium3_BYTES 3309
 
 #define pqcrystals_dilithium3_ref_PUBLICKEYBYTES pqcrystals_dilithium3_PUBLICKEYBYTES
 #define pqcrystals_dilithium3_ref_SECRETKEYBYTES pqcrystals_dilithium3_SECRETKEYBYTES
@@ -60,7 +60,7 @@ int pqcrystals_dilithium3_ref_open(uint8_t *m, size_t *mlen,
 
 #define pqcrystals_dilithium5_PUBLICKEYBYTES 2592
 #define pqcrystals_dilithium5_SECRETKEYBYTES 4896
-#define pqcrystals_dilithium5_BYTES 4595
+#define pqcrystals_dilithium5_BYTES 4627
 
 #define pqcrystals_dilithium5_ref_PUBLICKEYBYTES pqcrystals_dilithium5_PUBLICKEYBYTES
 #define pqcrystals_dilithium5_ref_SECRETKEYBYTES pqcrystals_dilithium5_SECRETKEYBYTES

--- a/ref/packing.h
+++ b/ref/packing.h
@@ -18,7 +18,7 @@ void pack_sk(uint8_t sk[CRYPTO_SECRETKEYBYTES],
              const polyveck *s2);
 
 #define pack_sig DILITHIUM_NAMESPACE(pack_sig)
-void pack_sig(uint8_t sig[CRYPTO_BYTES], const uint8_t c[SEEDBYTES], const polyvecl *z, const polyveck *h);
+void pack_sig(uint8_t sig[CRYPTO_BYTES], const uint8_t c[CTILDEBYTES], const polyvecl *z, const polyveck *h);
 
 #define unpack_pk DILITHIUM_NAMESPACE(unpack_pk)
 void unpack_pk(uint8_t rho[SEEDBYTES], polyveck *t1, const uint8_t pk[CRYPTO_PUBLICKEYBYTES]);
@@ -33,6 +33,6 @@ void unpack_sk(uint8_t rho[SEEDBYTES],
                const uint8_t sk[CRYPTO_SECRETKEYBYTES]);
 
 #define unpack_sig DILITHIUM_NAMESPACE(unpack_sig)
-int unpack_sig(uint8_t c[SEEDBYTES], polyvecl *z, polyveck *h, const uint8_t sig[CRYPTO_BYTES]);
+int unpack_sig(uint8_t c[CTILDEBYTES], polyvecl *z, polyveck *h, const uint8_t sig[CRYPTO_BYTES]);
 
 #endif

--- a/ref/test/assert-params.c
+++ b/ref/test/assert-params.c
@@ -1,0 +1,32 @@
+/*
+This code ensures that the defines in api.h are aligned with the ones in param.h
+It doesnt generate any executable code.
+*/
+
+#include "../params.h"
+#include "../api.h"
+
+#define STR_HELPER(x) #x
+#define STR(x) STR_HELPER(x)
+
+#define pqcrystals_dilithium(mode, val) pqcrystals_dilithium_(mode, val)
+#define pqcrystals_dilithium_(mode, val) pqcrystals_dilithium##mode##_##val
+
+#define pqcrystals_dilithium_PUBLICKEYBYTES pqcrystals_dilithium(DILITHIUM_MODE, PUBLICKEYBYTES)
+#define pqcrystals_dilithium_SECRETKEYBYTES pqcrystals_dilithium(DILITHIUM_MODE, SECRETKEYBYTES)
+#define pqcrystals_dilithium_BYTES pqcrystals_dilithium(DILITHIUM_MODE, BYTES)
+
+#if pqcrystals_dilithium_PUBLICKEYBYTES != CRYPTO_PUBLICKEYBYTES
+#pragma message "building dilithium" STR(DILITHIUM_MODE)
+#error pqcrystals_dilithium_PUBLICKEYBYTES != CRYPTO_PUBLICKEYBYTES
+#endif
+
+#if pqcrystals_dilithium_SECRETKEYBYTES != CRYPTO_SECRETKEYBYTES
+#pragma message "building dilithium" STR(DILITHIUM_MODE)
+#error pqcrystals_dilithium_SECRETKEYBYTES != CRYPTO_SECRETKEYBYTES
+#endif
+
+#if pqcrystals_dilithium_BYTES != CRYPTO_BYTES
+#pragma message "building dilithium" STR(DILITHIUM_MODE)
+#error pqcrystals_dilithium_BYTES != CRYPTO_BYTES
+#endif


### PR DESCRIPTION
- fix api.h constants in ref and avx2
- fix pack_sig() and unpack_sig() prototypes in ref

- adds build time check to assert correctness of api.h constants

address issues #78 and #80