### PR TITLE
Updates to FIPS204 (needed for ACVP testing)

### DIFF
--- a/avx2/poly.c
+++ b/avx2/poly.c
@@ -664,16 +664,16 @@ void poly_uniform_gamma1_4x(poly *a0,
 *              SHAKE256(seed).
 *
 * Arguments:   - poly *c: pointer to output polynomial
-*              - const uint8_t mu[]: byte array containing seed of length SEEDBYTES
+*              - const uint8_t mu[]: byte array containing seed of length CTILDEBYTES
 **************************************************/
-void poly_challenge(poly * restrict c, const uint8_t seed[SEEDBYTES]) {
+void poly_challenge(poly * restrict c, const uint8_t seed[CTILDEBYTES]) {
   unsigned int i, b, pos;
   uint64_t signs;
   ALIGNED_UINT8(SHAKE256_RATE) buf;
   keccak_state state;
 
   shake256_init(&state);
-  shake256_absorb(&state, seed, SEEDBYTES);
+  shake256_absorb(&state, seed, CTILDEBYTES);
   shake256_finalize(&state);
   shake256_squeezeblocks(buf.coeffs, 1, &state);
 

--- a/avx2/poly.h
+++ b/avx2/poly.h
@@ -53,7 +53,7 @@ void poly_uniform_gamma1_preinit(poly *a, stream256_state *state);
 #define poly_uniform_gamma1 DILITHIUM_NAMESPACE(poly_uniform_gamma1)
 void poly_uniform_gamma1(poly *a, const uint8_t seed[CRHBYTES], uint16_t nonce);
 #define poly_challenge DILITHIUM_NAMESPACE(poly_challenge)
-void poly_challenge(poly *c, const uint8_t seed[SEEDBYTES]);
+void poly_challenge(poly *c, const uint8_t seed[CTILDEBYTES]);
 
 #define poly_uniform_4x DILITHIUM_NAMESPACE(poly_uniform_4x)
 void poly_uniform_4x(poly *a0,

--- a/ref/poly.c
+++ b/ref/poly.c
@@ -484,16 +484,16 @@ void poly_uniform_gamma1(poly *a,
 *              SHAKE256(seed).
 *
 * Arguments:   - poly *c: pointer to output polynomial
-*              - const uint8_t mu[]: byte array containing seed of length SEEDBYTES
+*              - const uint8_t mu[]: byte array containing seed of length CTILDEBYTES
 **************************************************/
-void poly_challenge(poly *c, const uint8_t seed[SEEDBYTES]) {
+void poly_challenge(poly *c, const uint8_t seed[CTILDEBYTES]) {
   unsigned int i, b, pos;
   uint64_t signs;
   uint8_t buf[SHAKE256_RATE];
   keccak_state state;
 
   shake256_init(&state);
-  shake256_absorb(&state, seed, SEEDBYTES);
+  shake256_absorb(&state, seed, CTILDEBYTES);
   shake256_finalize(&state);
   shake256_squeezeblocks(buf, 1, &state);
 

--- a/ref/poly.h
+++ b/ref/poly.h
@@ -51,7 +51,7 @@ void poly_uniform_gamma1(poly *a,
                          const uint8_t seed[CRHBYTES],
                          uint16_t nonce);
 #define poly_challenge DILITHIUM_NAMESPACE(poly_challenge)
-void poly_challenge(poly *c, const uint8_t seed[SEEDBYTES]);
+void poly_challenge(poly *c, const uint8_t seed[CTILDEBYTES]);
 
 #define polyeta_pack DILITHIUM_NAMESPACE(polyeta_pack)
 void polyeta_pack(uint8_t *r, const poly *a);

--- a/ref/sign.c
+++ b/ref/sign.c
@@ -143,7 +143,7 @@ rej:
   shake256_absorb(&state, sig, K*POLYW1_PACKEDBYTES);
   shake256_finalize(&state);
   shake256_squeeze(sig, CTILDEBYTES, &state);
-  poly_challenge(&cp, sig); /* uses only the first SEEDBYTES bytes of sig */
+  poly_challenge(&cp, sig); /* uses only the first CTILDEBYTES bytes of sig */
   poly_ntt(&cp);
 
   /* Compute z, reject if it reveals secret */
@@ -260,7 +260,7 @@ int crypto_sign_verify(const uint8_t *sig,
   shake256_squeeze(mu, CRHBYTES, &state);
 
   /* Matrix-vector multiplication; compute Az - c2^dt1 */
-  poly_challenge(&cp, c); /* uses only the first SEEDBYTES bytes of c */
+  poly_challenge(&cp, c); /* uses only the first CTILDEBYTES bytes of c */
   polyvec_matrix_expand(mat, rho);
 
   polyvecl_ntt(&z);

--- a/ref/sign.h
+++ b/ref/sign.h
@@ -8,7 +8,7 @@
 #include "poly.h"
 
 #define challenge DILITHIUM_NAMESPACE(challenge)
-void challenge(poly *c, const uint8_t seed[SEEDBYTES]);
+void challenge(poly *c, const uint8_t seed[CTILDEBYTES]);
 
 #define crypto_sign_keypair DILITHIUM_NAMESPACE(keypair)
 int crypto_sign_keypair(uint8_t *pk, uint8_t *sk);


### PR DESCRIPTION
To comply with [NISTs ACVP Demo](https://github.com/usnistgov/ACVP-Server/releases#:~:text=NOTE%3A%20The%20ML%2DDSA%20testing%20was%20updated%20on%205/23/24%20to%20incorporate%20updates%20to%20the%20FIPS%20204%20draft), changed SampleInBall to take all of CTILDBYTES, rather than just the first 256 bits.