### PR TITLE
Support cmake build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ PQCsignKAT_Dilithium5.rsp
 tvecs2
 tvecs3
 tvecs5
+/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,14 @@
+# CMake minimum version and project details
+cmake_minimum_required(VERSION 3.16)
+project(PQCDilithium VERSION 1.0 LANGUAGES C CXX ASM)
+
+# Set C++ standard
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+
+# Option to enable/disable tests
+option(ENABLE_TESTS "Enable Unit Tests" ON)
+
+# Set the output directories for binaries and libraries
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,3 +15,4 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 
 find_package(OpenSSL REQUIRED)
 add_subdirectory(ref)
+add_subdirectory(avx2)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,3 +12,6 @@ option(ENABLE_TESTS "Enable Unit Tests" ON)
 # Set the output directories for binaries and libraries
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+
+find_package(OpenSSL REQUIRED)
+add_subdirectory(ref)

--- a/avx2/CMakeLists.txt
+++ b/avx2/CMakeLists.txt
@@ -1,0 +1,85 @@
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wextra")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wpedantic")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wmissing-prototypes")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wredundant-decls")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wshadow")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wpointer-arith")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mavx2")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mpopcnt")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -march=native")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mtune=native")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3")
+
+set(securitylevel 2 3 5)
+
+# build fips202 shared library
+add_library(pqccrystals_fips202x4_avx2 SHARED fips202x4.c f1600x4.S fips202.c)
+
+set(SRCS
+  sign.c
+  packing.c
+  polyvec.c
+  poly.c
+  ntt.S
+  invntt.S
+  pointwise.S
+  shuffle.S
+  consts.c
+  rejsample.c
+  rounding.c
+  symmetric-shake.c
+)
+
+# build algorithm shared library
+foreach(level IN LISTS securitylevel)
+  set(name pqccrystals_dilithium${level}_avx2)
+
+  add_library(${name} SHARED ${SRCS})
+  target_link_libraries(${name} pqccrystals_fips202x4_avx2)
+  target_compile_definitions(${name} PUBLIC DILITHIUM_MODE=${level})
+  target_include_directories(${name} PRIVATE .)
+endforeach()
+
+# build test_dilithium
+foreach(level IN LISTS securitylevel)
+  add_executable(test_dilithium${level}_avx2 test/test_dilithium.c)
+  target_link_libraries(test_dilithium${level}_avx2
+    pqccrystals_fips202x4_avx2
+    pqccrystals_dilithium${level}_avx2
+    randombytes
+  )
+endforeach()
+
+# build test_vector
+foreach(level IN LISTS securitylevel)
+  add_executable(test_vectors${level}_avx2 test/test_vectors.c)
+  target_link_libraries(test_vectors${level}_avx2
+    pqccrystals_fips202x4_avx2
+    pqccrystals_dilithium${level}_avx2)
+endforeach()
+
+# build test_speed
+foreach(level IN LISTS securitylevel)
+  add_executable(test_speed${level}_avx2
+    test/cpucycles.c
+    test/speed_print.c
+    test/test_speed.c
+  )
+  target_link_libraries(test_speed${level}_avx2
+    pqccrystals_fips202x4_avx2
+    pqccrystals_dilithium${level}_avx2
+    randombytes
+  )
+endforeach()
+
+# build test_mul
+add_executable(test_mul_avx2
+  test/test_mul.c
+)
+target_link_libraries(test_mul_avx2
+  pqccrystals_fips202x4_avx2
+  pqccrystals_dilithium2_avx2
+  randombytes
+)

--- a/ref/CMakeLists.txt
+++ b/ref/CMakeLists.txt
@@ -1,0 +1,93 @@
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wextra")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wpedantic")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wmissing-prototypes")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wredundant-decls")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wshadow")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wpointer-arith")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fomit-frame-pointer")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -z noexecstack")
+set(NISTFLAGS "${NISTFLAGS}" -Wno-unused-result -O3 -fomit-frame-pointer)
+
+set(securitylevel 2 3 5)
+
+# build randombytes
+add_library(randombytes SHARED randombytes.c)
+
+# build nist rng
+add_library(rng SHARED nistkat/rng.c)
+target_link_libraries(rng OpenSSL::Crypto)
+
+set(SRCS
+  sign.c
+  packing.c
+  polyvec.c
+  poly.c
+  ntt.c
+  reduce.c
+  rounding.c
+  symmetric-shake.c
+)
+
+add_library(pqccrystals_fips202_ref SHARED fips202.c)
+
+# build algorithm shared library
+foreach(level IN LISTS securitylevel)
+  set(name pqccrystals_dilithium${level}_ref)
+
+  add_library(${name} SHARED ${SRCS})
+  target_link_libraries(${name} pqccrystals_fips202_ref)
+  target_compile_definitions(${name} PUBLIC DILITHIUM_MODE=${level})
+endforeach()
+
+# build test_dilithium
+foreach(level IN LISTS securitylevel)
+  add_executable(test_dilithium${level} test/test_dilithium.c)
+  target_link_libraries(test_dilithium${level}
+    pqccrystals_fips202_ref
+    pqccrystals_dilithium${level}_ref
+    randombytes)
+endforeach()
+
+# build test_vector
+foreach(level IN LISTS securitylevel)
+  add_executable(test_vectors${level} test/test_vectors.c)
+  target_link_libraries(test_vectors${level}
+    pqccrystals_fips202_ref
+    pqccrystals_dilithium${level}_ref)
+endforeach()
+
+# build test_speed
+foreach(level IN LISTS securitylevel)
+  add_executable(test_speed${level}
+    test/cpucycles.c
+    test/speed_print.c
+    test/test_speed.c
+	)
+  target_link_libraries(test_speed${level}
+    pqccrystals_fips202_ref
+    pqccrystals_dilithium${level}_ref
+    randombytes)
+endforeach()
+
+# build test_mul
+add_executable(test_mul
+    test/test_mul.c
+)
+target_link_libraries(test_mul
+    pqccrystals_fips202_ref
+    pqccrystals_dilithium2_ref
+    randombytes
+)
+
+# build nistkat
+foreach(level IN LISTS securitylevel)
+  add_compile_options(${NISTFLAGS})
+  add_executable(PQCgenKAT_sign${level} nistkat/PQCgenKAT_sign.c)
+  target_link_libraries(PQCgenKAT_sign${level}
+    pqccrystals_fips202_ref
+    pqccrystals_dilithium${level}_ref
+    rng)
+endforeach()


### PR DESCRIPTION
Support cmake build. There are some difference between cmake and make:  
Since cmake does not support different target with same name, all the library in avx2 directory will have `_avx2` suffix in its name.