### PR TITLE
add SUF-CMA claim in META.yml

### DIFF
--- a/Dilithium2_META.yml
+++ b/Dilithium2_META.yml
@@ -1,6 +1,7 @@
 name: Dilithium2
 type: signature
 claimed-nist-level: 2
+claimed-security: SUF-CMA
 length-public-key: 1312
 length-secret-key: 2560
 length-signature: 2420

--- a/Dilithium3_META.yml
+++ b/Dilithium3_META.yml
@@ -1,6 +1,7 @@
 name: Dilithium3
 type: signature
 claimed-nist-level: 3
+claimed-security: SUF-CMA
 length-public-key: 1952
 length-secret-key: 4032
 length-signature: 3309

--- a/Dilithium5_META.yml
+++ b/Dilithium5_META.yml
@@ -1,6 +1,7 @@
 name: Dilithium5
 type: signature
 claimed-nist-level: 5
+claimed-security: SUF-CMA
 length-public-key: 2592
 length-secret-key: 4896
 length-signature: 4627


### PR DESCRIPTION
This pull request simply adds `claimed-security: SUF-CMA` to `META.yml`, as declared in FIPS 204:

> ML-DSA is designed to be strongly existentially unforgeable under chosen message attack (SUF-CMA).
> That is, it is expected that even if an adversary can get the honest party to sign arbitrary messages, the
> adversary cannot create any additional valid signatures based on the signer’s public key, including on
> messages for which the signer has already provided a signature.

The purpose is to allow liboqs to [test](https://github.com/open-quantum-safe/liboqs/pull/2090) this property after importing ML-DSA.